### PR TITLE
Fix building Docker image for recurring jobs container

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 De Urgență [was prototyped](https://civiclabs.ro/ro/solutions/stay-together) in [Code for Romania](https://code4.ro/ro)'s research project, [Civic Labs](https://civiclabs.ro/ro).
 
-The application aims to inform citizens about how to react to the first critical hours in a crysis situation (like that of an earthquake). 
+The application aims to inform citizens about how to react to the first critical hours in a crisis situation (like that of an earthquake).
 
 It also aims to build healthy habits that become ingrained with time, so that, when the critical moment arrives, each person knows what the key first steps to keeping themselves safe are. 
 

--- a/Src/DeUrgenta.Api/Extensions/SwaggerExtensions.cs
+++ b/Src/DeUrgenta.Api/Extensions/SwaggerExtensions.cs
@@ -39,7 +39,7 @@ namespace DeUrgenta.Api.Extensions
                 {
                     Version = "v1",
                     Title = "De Urgenta API",
-                    Description = "The application aims to inform citizens about how to react to the first critical hours in a crysis situation (like that of an earthquake).",
+                    Description = "The application aims to inform citizens about how to react to the first critical hours in a crisis situation (like that of an earthquake).",
                     TermsOfService = new Uri("https://github.com/code4romania/de-urgenta-backend"),
                     Contact = new OpenApiContact
                     {

--- a/Src/DeUrgenta.RecurringJobs.Dockerfile
+++ b/Src/DeUrgenta.RecurringJobs.Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
 WORKDIR /src
 COPY ["DeUrgenta.RecurringJobs/DeUrgenta.RecurringJobs.csproj", "DeUrgenta.RecurringJobs/"]
 COPY ["DeUrgenta.Domain/DeUrgenta.Domain.csproj", "DeUrgenta.Domain/"]

--- a/Src/docker-compose.yml
+++ b/Src/docker-compose.yml
@@ -24,13 +24,13 @@
         ASPNETCORE_URLS: ${ASPNETCORE_URLS}
         ConnectionStrings__DbConnectionString: ${DB_CONNECTION_STRING}
         ConnectionStrings__IdentityDbConnectionString: ${DB_CONNECTION_STRING}
-        SendGrid__ApiKey: ${SENDGRID_API_KEY}        
+        SendGrid__ApiKey: ${SENDGRID_API_KEY}
       ports:
         - 5040:80
       restart: unless-stopped
 
-    recurent-jobs:
-      container_name: deurgenta_recurent_jobs
+    recurring-jobs:
+      container_name: deurgenta_recurring_jobs
       depends_on:
         - "postgres"
       build:


### PR DESCRIPTION
### What does it fix?

Trying to follow the "Get started with docker-compose" instructions from the readme on Ubuntu leads to hundreds of package errors when building the recurring jobs container image: `The repository countersignature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain` .

After a short search on the internet I've found [this issue](https://github.com/NuGet/Home/issues/10491) with Microsoft's official .NET base images. I've fixed the problem by changing the image version from `5.0` to `5.0-buster-slim` in the `DeUrgenta.RecurringJobs.Dockerfile` file. This change was already in place for the main `Dockerfile`.

I've also:
- renamed the `recurent-jobs` service to `recurring-jobs` in `docker-compose.yml`, to match the project name. 
- fixed a minor spelling error in the readme/API description ("crisis" is `criză`, "crysis" is the video game from CryTek :laughing:).

### How has it been tested?

After making these changes, I was successfully able to run the project locally on my laptop.
