### PR TITLE
Transitioned tests from Shouldly to FluentAssertions

### DIFF
--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/AddBackpackItemHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/AddBackpackItemHandlerShould.cs
@@ -8,7 +8,7 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
@@ -38,7 +38,7 @@ namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
             var result = await sut.Handle(new AddBackpackItem("a-sub", Guid.NewGuid(), new BackpackItemRequest()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/CreateBackpackHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/CreateBackpackHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
             var result = await sut.Handle(new CreateBackpack("a-sub", new BackpackModelRequest()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/DeleteBackpackHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/DeleteBackpackHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
             var result = await sut.Handle(new DeleteBackpack("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/DeleteBackpackItemHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/DeleteBackpackItemHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
             var result = await sut.Handle(new DeleteBackpackItem("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/InviteToBackpackContributorsHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/InviteToBackpackContributorsHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
             var result = await sut.Handle(new InviteToBackpackContributors("a-sub", Guid.NewGuid(), Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/RemoveContributorHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/RemoveContributorHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
             var result = await sut.Handle(new RemoveContributor("a-sub", Guid.NewGuid(), Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/RemoveCurrentUserFromContributorsHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/RemoveCurrentUserFromContributorsHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
             var result = await sut.Handle(new RemoveCurrentUserFromContributors("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/UpdateBackpackHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/UpdateBackpackHandlerShould.cs
@@ -8,7 +8,7 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
@@ -38,7 +38,7 @@ namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
             var result = await sut.Handle(new UpdateBackpack("a-sub", Guid.NewGuid(), new BackpackModelRequest()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/UpdateBackpackItemHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/UpdateBackpackItemHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
             var result = await sut.Handle(new UpdateBackpackItem("a-sub", Guid.NewGuid(), new Models.BackpackItemRequest()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/DeUrgenta.Backpack.Api.Tests.csproj
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/DeUrgenta.Backpack.Api.Tests.csproj
@@ -10,7 +10,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
 		<PackageReference Include="NSubstitute" Version="4.2.2" />
 		<PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.14" />
-		<PackageReference Include="Shouldly" Version="4.0.3" />
+		<PackageReference Include="FluentAssertions" Version="6.1.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/QueryHandlers/GetBackpackCategoryItemsHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/QueryHandlers/GetBackpackCategoryItemsHandlerShould.cs
@@ -8,7 +8,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.QueryHandlers
@@ -38,7 +38,7 @@ namespace DeUrgenta.Backpack.Api.Tests.QueryHandlers
             var result = await sut.Handle(new GetBackpackCategoryItems("a-sub", Guid.NewGuid(), BackpackCategoryType.FirstAid), CancellationToken.None);
              
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/QueryHandlers/GetBackpackContributorsHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/QueryHandlers/GetBackpackContributorsHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.QueryHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Backpack.Api.Tests.QueryHandlers
             var result = await sut.Handle(new GetBackpackContributors("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/QueryHandlers/GetBackpackItemsHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/QueryHandlers/GetBackpackItemsHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.QueryHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Backpack.Api.Tests.QueryHandlers
             var result = await sut.Handle(new GetBackpackItems("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/QueryHandlers/GetBackpacksHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/QueryHandlers/GetBackpacksHandlerShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.QueryHandlers
@@ -36,7 +36,7 @@ namespace DeUrgenta.Backpack.Api.Tests.QueryHandlers
             var result = await sut.Handle(new GetBackpacks("a-sub"), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/QueryHandlers/GetMyBackpacksHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/QueryHandlers/GetMyBackpacksHandlerShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.QueryHandlers
@@ -36,7 +36,7 @@ namespace DeUrgenta.Backpack.Api.Tests.QueryHandlers
             var result = await sut.Handle(new GetMyBackpacks("a-sub"), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/AddBackpackItemValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/AddBackpackItemValidatorShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AddBackpackItem(sub, Guid.NewGuid(), new BackpackItemRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AddBackpackItem(nonContributor.Sub, backpackId, new BackpackItemRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
 
@@ -98,7 +98,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(command);
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/CreateBackpackValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/CreateBackpackValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Backpack.Api.Validators;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new CreateBackpack(sub, new BackpackModelRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new CreateBackpack(userSub, new BackpackModelRequest()));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/DeleteBackpackItemValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/DeleteBackpackItemValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteBackpackItem(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -75,7 +75,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteBackpackItem(nonContributor.Sub, backpackItemId));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -104,7 +104,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteBackpackItem(contributorSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -141,7 +141,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteBackpackItem(contributorSub, backpackItemId));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/DeleteBackpackValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/DeleteBackpackValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteBackpack(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteBackpack(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteBackpack(userSub, backpack.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteBackpack(userSub, backpack.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/GetBackpackCategoryItemsValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/GetBackpackCategoryItemsValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetBackpackCategoryItems(sub, Guid.NewGuid(), BackpackCategoryType.WaterAndFood));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetBackpackCategoryItems(nonContributor.Sub, backpackId, BackpackCategoryType.FirstAid));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetBackpackCategoryItems(contributorSub, backpackId, BackpackCategoryType.WaterAndFood));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
         
     }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/GetBackpackContributorsValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/GetBackpackContributorsValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetBackpackContributors(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
 
@@ -53,7 +53,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetBackpackContributors(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetBackpackContributors(userSub, backpack.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -111,7 +111,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetBackpackContributors(userSub, backpack.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
 
         [Fact]
@@ -135,7 +135,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetBackpackContributors(userSub, backpack.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/GetBackpackItemsValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/GetBackpackItemsValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetBackpackItems(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetBackpackItems(nonContributor.Sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetBackpackItems(contributorSub, backpackId));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/GetBackpacksValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/GetBackpacksValidatorShould.cs
@@ -5,7 +5,7 @@ using DeUrgenta.Backpack.Api.Validators;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.Validators
@@ -33,7 +33,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetBackpacks(sub));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetBackpacks(userSub));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/GetMyBackpacksValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/GetMyBackpacksValidatorShould.cs
@@ -5,7 +5,7 @@ using DeUrgenta.Backpack.Api.Validators;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.Validators
@@ -33,7 +33,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetMyBackpacks(sub));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetMyBackpacks(userSub));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/InviteToBackpackContributorsValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/InviteToBackpackContributorsValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new InviteToBackpackContributors(sub, Guid.NewGuid(), Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new InviteToBackpackContributors(userSub, backpack.Id, user.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -79,7 +79,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new InviteToBackpackContributors(userSub, Guid.NewGuid(), Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new InviteToBackpackContributors(userSub, backpack.Id, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -146,7 +146,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new InviteToBackpackContributors(userSub, backpackInvite.Id, invitedContributor.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -179,7 +179,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new InviteToBackpackContributors(userSub, backpack.Id, nonContributor.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
 
         [Fact]
@@ -211,7 +211,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new InviteToBackpackContributors(userSub, backpack.Id, nonContributor.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/RemoveContributorValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/RemoveContributorValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveContributor(sub, Guid.NewGuid(), Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
 
@@ -63,7 +63,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveContributor(userSub, backpack.Id, owner.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
 
         }
 
@@ -91,7 +91,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveContributor(userSub, backpack.Id, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -115,7 +115,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveContributor(userSub, Guid.NewGuid(), contributor.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -149,7 +149,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveContributor(contributorSub, backpack.Id, owner.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -181,7 +181,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveContributor(userSub, backpack.Id, backpackContributor.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/RemoveCurrentUserFromContributorsValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/RemoveCurrentUserFromContributorsValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveCurrentUserFromContributors(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveCurrentUserFromContributors(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveCurrentUserFromContributors(userSub, backpack.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
 
@@ -107,7 +107,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveCurrentUserFromContributors(userSub, backpack.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveCurrentUserFromContributors(userSub, backpack.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/UpdateBackpackItemValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/UpdateBackpackItemValidatorShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateBackpackItem(sub, Guid.NewGuid(), new BackpackItemRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateBackpackItem(nonContributor.Sub, backpackId, new BackpackItemRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateBackpackItem(contributorSub, Guid.NewGuid(), new BackpackItemRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
        
 
@@ -133,7 +133,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateBackpackItem(contributorSub, backpackItemId, new BackpackItemRequest()));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/UpdateBackpackValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/Validators/UpdateBackpackValidatorShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.Validators
@@ -35,7 +35,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateBackpack(sub, Guid.NewGuid(), new BackpackModelRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateBackpack(userSub, Guid.NewGuid(), new BackpackModelRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateBackpack(backpackContributorSub, Guid.NewGuid(), new BackpackModelRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace DeUrgenta.Backpack.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateBackpack(userSub, backpack.Id, new BackpackModelRequest()));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Certifications.Api.Tests/CommandHandlers/CreateCertificationHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Certifications.Api.Tests/CommandHandlers/CreateCertificationHandlerShould.cs
@@ -11,7 +11,7 @@ using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Certifications.Api.Tests.CommandHandlers
@@ -42,7 +42,7 @@ namespace DeUrgenta.Certifications.Api.Tests.CommandHandlers
             var result = await sut.Handle(new CreateCertification("a-sub", new CertificationRequest()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace DeUrgenta.Certifications.Api.Tests.CommandHandlers
             var result = await sut.Handle(createCertification, CancellationToken.None);
 
             //Assert
-            result.IsSuccess.ShouldBeTrue();
+            result.IsSuccess.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Certifications.Api.Tests/CommandHandlers/DeleteCertificationHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Certifications.Api.Tests/CommandHandlers/DeleteCertificationHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Certifications.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Certifications.Api.Tests.CommandHandlers
             var result = await sut.Handle(new DeleteCertification("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Certifications.Api.Tests/CommandHandlers/UpdateCertificationHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Certifications.Api.Tests/CommandHandlers/UpdateCertificationHandlerShould.cs
@@ -12,7 +12,7 @@ using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Certifications.Api.Tests.CommandHandlers
@@ -43,7 +43,7 @@ namespace DeUrgenta.Certifications.Api.Tests.CommandHandlers
             var result = await sut.Handle(new UpdateCertification("a-sub", Guid.NewGuid(), new CertificationRequest()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace DeUrgenta.Certifications.Api.Tests.CommandHandlers
             var result = await sut.Handle(updateCertification, CancellationToken.None);
 
             //Assert
-            result.IsSuccess.ShouldBeTrue();
+            result.IsSuccess.Should().BeTrue();
         }
 
         private async Task SetupExistingCertification(Guid certificationId)

--- a/Src/Tests/DeUrgenta.Certifications.Api.Tests/DeUrgenta.Certifications.Api.Tests.csproj
+++ b/Src/Tests/DeUrgenta.Certifications.Api.Tests/DeUrgenta.Certifications.Api.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/Tests/DeUrgenta.Certifications.Api.Tests/QueryHandlers/GetCertificationsHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Certifications.Api.Tests/QueryHandlers/GetCertificationsHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Certifications.Api.Tests.QueryHandlers
@@ -38,7 +38,7 @@ namespace DeUrgenta.Certifications.Api.Tests.QueryHandlers
             var result = await sut.Handle(new GetCertifications("a-sub"), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Certifications.Api.Tests/Validators/CreateCertificationValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Certifications.Api.Tests/Validators/CreateCertificationValidatorShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Certifications.Api.Tests.Validators
@@ -35,7 +35,7 @@ namespace DeUrgenta.Certifications.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new CreateCertification(sub, new CertificationRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace DeUrgenta.Certifications.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new CreateCertification(userSub, new CertificationRequest()));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Certifications.Api.Tests/Validators/DeleteCertificationValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Certifications.Api.Tests/Validators/DeleteCertificationValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Certifications.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Certifications.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteCertification(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace DeUrgenta.Certifications.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteCertification(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace DeUrgenta.Certifications.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteCertification(userSub, certificationId));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace DeUrgenta.Certifications.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteCertification(ownerSub, certificationId));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
 
     }

--- a/Src/Tests/DeUrgenta.Certifications.Api.Tests/Validators/GetCertificationsValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Certifications.Api.Tests/Validators/GetCertificationsValidatorShould.cs
@@ -5,7 +5,7 @@ using DeUrgenta.Certifications.Api.Validators;
 using DeUrgenta.Domain;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Certifications.Api.Tests.Validators
@@ -32,7 +32,7 @@ namespace DeUrgenta.Certifications.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetCertifications(sub));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace DeUrgenta.Certifications.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetCertifications(userSub));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Certifications.Api.Tests/Validators/UpdateCertificationValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Certifications.Api.Tests/Validators/UpdateCertificationValidatorShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Certifications.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Certifications.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateCertification(sub, Guid.NewGuid(), new CertificationRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace DeUrgenta.Certifications.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateCertification(userSub, Guid.NewGuid(), new CertificationRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace DeUrgenta.Certifications.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateCertification(userSub, certificationId, new CertificationRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace DeUrgenta.Certifications.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateCertification(ownerSub, certificationId, new CertificationRequest()));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
 
     }

--- a/Src/Tests/DeUrgenta.Events.Api.Tests/DeUrgenta.Events.Api.Tests.csproj
+++ b/Src/Tests/DeUrgenta.Events.Api.Tests/DeUrgenta.Events.Api.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/Tests/DeUrgenta.Events.Api.Tests/QueryHandlers/GetEventCitiesHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Events.Api.Tests/QueryHandlers/GetEventCitiesHandlerShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Events.Api.Queries;
 using DeUrgenta.Events.Api.QueryHandlers;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Events.Api.Tests.QueryHandlers
@@ -36,7 +36,7 @@ namespace DeUrgenta.Events.Api.Tests.QueryHandlers
             var result = await sut.Handle(new GetEventCities(null), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Events.Api.Tests/QueryHandlers/GetEventHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Events.Api.Tests/QueryHandlers/GetEventHandlerShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Events.Api.Queries;
 using DeUrgenta.Events.Api.QueryHandlers;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Events.Api.Tests.QueryHandlers
@@ -36,7 +36,7 @@ namespace DeUrgenta.Events.Api.Tests.QueryHandlers
             var result = await sut.Handle(new GetEvent(new Models.EventModelRequest()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Events.Api.Tests/QueryHandlers/GetEventTypesHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Events.Api.Tests/QueryHandlers/GetEventTypesHandlerShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Events.Api.Queries;
 using DeUrgenta.Events.Api.QueryHandlers;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Events.Api.Tests.QueryHandlers
@@ -36,7 +36,7 @@ namespace DeUrgenta.Events.Api.Tests.QueryHandlers
             var result = await sut.Handle(new GetEventTypes(), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Events.Api.Tests/Validators/GetEventCitiesValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Events.Api.Tests/Validators/GetEventCitiesValidatorShould.cs
@@ -3,7 +3,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Events.Api.Queries;
 using DeUrgenta.Events.Api.Validators;
 using DeUrgenta.Tests.Helpers;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Events.Api.Tests.Validators
@@ -30,7 +30,7 @@ namespace DeUrgenta.Events.Api.Tests.Validators
             bool isValid = await sut.IsValidAsync(new GetEventCities(eventTypeId));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Theory]
@@ -46,7 +46,7 @@ namespace DeUrgenta.Events.Api.Tests.Validators
             bool isValid = await sut.IsValidAsync(new GetEventCities(eventTypeId));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Events.Api.Tests/Validators/GetEventTypesValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Events.Api.Tests/Validators/GetEventTypesValidatorShould.cs
@@ -2,7 +2,7 @@
 using DeUrgenta.Events.Api.Queries;
 using DeUrgenta.Events.Api.Validators;
 using DeUrgenta.Tests.Helpers;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Events.Api.Tests.Validators
@@ -20,7 +20,7 @@ namespace DeUrgenta.Events.Api.Tests.Validators
             bool isValid = await sut.IsValidAsync(new GetEventTypes());
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Events.Api.Tests/Validators/GetEventValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Events.Api.Tests/Validators/GetEventValidatorShould.cs
@@ -3,7 +3,7 @@ using DeUrgenta.Domain;
 using DeUrgenta.Events.Api.Queries;
 using DeUrgenta.Events.Api.Validators;
 using DeUrgenta.Tests.Helpers;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Events.Api.Tests.Validators
@@ -30,7 +30,7 @@ namespace DeUrgenta.Events.Api.Tests.Validators
             bool isValid = await sut.IsValidAsync(new GetEvent(new Models.EventModelRequest { EventTypeId = eventTypeId }));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Theory]
@@ -44,7 +44,7 @@ namespace DeUrgenta.Events.Api.Tests.Validators
             bool isValid = await sut.IsValidAsync(new GetEvent(new Models.EventModelRequest { EventTypeId = eventTypeId }));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/AddGroupHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/AddGroupHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Group.Api.Models;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
             var result = await sut.Handle(new AddGroup("a-sub", new GroupRequest()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/AddSafeLocationHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/AddSafeLocationHandlerShould.cs
@@ -8,7 +8,7 @@ using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Group.Api.Models;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
@@ -38,7 +38,7 @@ namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
             var result = await sut.Handle(new AddSafeLocation("a-sub", Guid.NewGuid(), new SafeLocationRequest()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/DeleteGroupHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/DeleteGroupHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Group.Api.CommandHandlers;
 using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
             var result = await sut.Handle(new DeleteGroup("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/DeleteSafeLocationHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/DeleteSafeLocationHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Group.Api.CommandHandlers;
 using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
             var result = await sut.Handle(new DeleteSafeLocation("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/InviteToGroupHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/InviteToGroupHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Group.Api.CommandHandlers;
 using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
@@ -39,7 +39,7 @@ namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
                 CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/LeaveGroupHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/LeaveGroupHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Group.Api.CommandHandlers;
 using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
             var result = await sut.Handle(new LeaveGroup("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/RemoveFromGroupHandler.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/RemoveFromGroupHandler.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Group.Api.CommandHandlers;
 using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
             var result = await sut.Handle(new RemoveFromGroup("a-sub", Guid.NewGuid(), Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/UpdateGroupHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/UpdateGroupHandlerShould.cs
@@ -8,7 +8,7 @@ using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Group.Api.Models;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
@@ -38,7 +38,7 @@ namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
             var result = await sut.Handle(new UpdateGroup("a-sub", Guid.NewGuid(), new GroupRequest()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/UpdateSafeLocationHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/UpdateSafeLocationHandlerShould.cs
@@ -8,7 +8,7 @@ using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Group.Api.Models;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
@@ -38,7 +38,7 @@ namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
             var result = await sut.Handle(new UpdateSafeLocation("a-sub", Guid.NewGuid(), new SafeLocationRequest()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/DeUrgenta.Group.Api.Tests.csproj
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/DeUrgenta.Group.Api.Tests.csproj
@@ -10,7 +10,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
 		<PackageReference Include="NSubstitute" Version="4.2.2" />
 		<PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.14" />
-		<PackageReference Include="Shouldly" Version="4.0.3" />
+		<PackageReference Include="FluentAssertions" Version="6.1.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -25,6 +25,10 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\DeUrgenta.Group.Api\DeUrgenta.Group.Api.csproj" />
 		<ProjectReference Include="..\DeUrgenta.Tests.Helpers\DeUrgenta.Tests.Helpers.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <None Remove="Validators\InviteToGroupValidatorShould.cs.orig" />
 	</ItemGroup>
 
 </Project>

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/QueriesHandlers/GetAdministeredGroupsHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/QueriesHandlers/GetAdministeredGroupsHandlerShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Group.Api.Queries;
 using DeUrgenta.Group.Api.QueryHandlers;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.QueriesHandlers
@@ -36,7 +36,7 @@ namespace DeUrgenta.Group.Api.Tests.QueriesHandlers
             var result = await sut.Handle(new GetAdministeredGroups("a-sub"), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/QueriesHandlers/GetGroupMembersHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/QueriesHandlers/GetGroupMembersHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Group.Api.Queries;
 using DeUrgenta.Group.Api.QueryHandlers;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.QueriesHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Group.Api.Tests.QueriesHandlers
             var result = await sut.Handle(new GetGroupMembers("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/QueriesHandlers/GetGroupSafeLocationsHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/QueriesHandlers/GetGroupSafeLocationsHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Group.Api.Queries;
 using DeUrgenta.Group.Api.QueryHandlers;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.QueriesHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.Group.Api.Tests.QueriesHandlers
             var result = await sut.Handle(new GetGroupSafeLocations("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/QueriesHandlers/GetMyGroupsHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/QueriesHandlers/GetMyGroupsHandlerShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Group.Api.Queries;
 using DeUrgenta.Group.Api.QueryHandlers;
 using DeUrgenta.Tests.Helpers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.QueriesHandlers
@@ -36,7 +36,7 @@ namespace DeUrgenta.Group.Api.Tests.QueriesHandlers
             var result = await sut.Handle(new GetMyGroups("a-sub"), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/AddGroupValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/AddGroupValidatorShould.cs
@@ -8,7 +8,7 @@ using DeUrgenta.Group.Api.Options;
 using DeUrgenta.Group.Api.Validators;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.Validators
@@ -38,7 +38,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AddGroup(sub, new GroupRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AddGroup(userSub, new GroupRequest()));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
         
         [Fact]
@@ -85,7 +85,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var result = await sut.IsValidAsync(new AddGroup(user.Sub, new GroupRequest {Name = "TestGroup"}));
 
             // Assert
-            result.ShouldBeFalse();
+            result.Should().BeFalse();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/AddSafeLocationValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/AddSafeLocationValidatorShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Group.Api.Models;
 using DeUrgenta.Group.Api.Validators;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.Validators
@@ -35,7 +35,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AddSafeLocation(sub, Guid.NewGuid(), new SafeLocationRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AddSafeLocation(userSub, Guid.NewGuid(), new SafeLocationRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AddSafeLocation(userSub, Guid.NewGuid(), new SafeLocationRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AddSafeLocation(userSub, Guid.NewGuid(), new SafeLocationRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -127,7 +127,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AddSafeLocation(userSub, group.Id, new SafeLocationRequest()));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/DeleteGroupValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/DeleteGroupValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Group.Api.Validators;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteGroup(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteGroup(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteGroup(userSub, group.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteGroup(userSub, group.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/DeleteSafeLocationValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/DeleteSafeLocationValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Group.Api.Validators;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteSafeLocation(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteSafeLocation(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteSafeLocation(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -109,7 +109,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteSafeLocation(userSub, groupSafeLocation.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -142,7 +142,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteSafeLocation(userSub, groupSafeLocation.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/GetAdministeredGroupsValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/GetAdministeredGroupsValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Group.Api.Queries;
 using DeUrgenta.Group.Api.Validators;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetAdministeredGroups(sub));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetAdministeredGroups(userSub));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/GetGroupMembersValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/GetGroupMembersValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Group.Api.Queries;
 using DeUrgenta.Group.Api.Validators;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetGroupMembers(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetGroupMembers(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -75,7 +75,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetGroupMembers(userSub, group.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -104,7 +104,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetGroupMembers(userSub, group.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
 
         [Fact]
@@ -130,7 +130,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetGroupMembers(userSub, group.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/GetGroupSafeLocationsValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/GetGroupSafeLocationsValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Group.Api.Queries;
 using DeUrgenta.Group.Api.Validators;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetGroupSafeLocations(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetGroupSafeLocations(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetGroupSafeLocations(userSub, group.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetGroupSafeLocations(userSub, group.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetGroupSafeLocations(userSub, group.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/GetMyGroupsValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/GetMyGroupsValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Group.Api.Queries;
 using DeUrgenta.Group.Api.Validators;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetMyGroups(sub));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetMyGroups(userSub));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/InviteToGroupValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/InviteToGroupValidatorShould.cs
@@ -8,7 +8,7 @@ using DeUrgenta.Group.Api.Options;
 using DeUrgenta.Group.Api.Validators;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.Validators
@@ -38,7 +38,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new InviteToGroup(sub, Guid.NewGuid(), Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new InviteToGroup(userSub, group.Id, user.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new InviteToGroup(userSub, Guid.NewGuid(), Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new InviteToGroup(userSub, group.Id, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -157,7 +157,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new InviteToGroup(userSub, group.Id, invitedGroupUser.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -191,7 +191,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new InviteToGroup(userSub, group.Id, nonGroupUser.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
 
         [Fact]
@@ -224,7 +224,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new InviteToGroup(userSub, group.Id, nonGroupUser.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
         
         [Fact]
@@ -276,7 +276,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var result = await sut.IsValidAsync(new InviteToGroup("a-sub", mainGroup.Id, user.Id));
 
             // Assert
-            result.ShouldBeFalse();
+            result.Should().BeFalse();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/LeaveGroupValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/LeaveGroupValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Group.Api.Validators;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new LeaveGroup(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new LeaveGroup(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new LeaveGroup(userSub, group.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
 
@@ -110,7 +110,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new LeaveGroup(userSub, group.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -141,7 +141,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new LeaveGroup(userSub, group.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/RemoveFromGroupValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/RemoveFromGroupValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Group.Api.Validators;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveFromGroup(sub, Guid.NewGuid(), Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveFromGroup(userSub, group.Id, admin.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
 
         }
 
@@ -93,7 +93,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveFromGroup(userSub, group.Id, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveFromGroup(userSub, Guid.NewGuid(), groupUser.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveFromGroup(groupUserSub, group.Id, groupUser.Id));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -184,7 +184,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RemoveFromGroup(userSub, group.Id, groupUser.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/UpdateGroupValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/UpdateGroupValidatorShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Group.Api.Models;
 using DeUrgenta.Group.Api.Validators;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.Validators
@@ -35,7 +35,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateGroup(sub, Guid.NewGuid(), new GroupRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateGroup(userSub, Guid.NewGuid(), new GroupRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateGroup(groupUserSub, Guid.NewGuid(), new GroupRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateGroup(userSub, group.Id, new GroupRequest()));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/UpdateSafeLocationValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/UpdateSafeLocationValidatorShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Group.Api.Models;
 using DeUrgenta.Group.Api.Validators;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.Validators
@@ -35,7 +35,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateSafeLocation(sub, Guid.NewGuid(), new SafeLocationRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateSafeLocation(userSub, Guid.NewGuid(), new SafeLocationRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -90,7 +90,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateSafeLocation(userSub, groupSafeLocation.Id, new SafeLocationRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -123,7 +123,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateSafeLocation(userSub, groupSafeLocation.Id, new SafeLocationRequest()));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/AcceptBackpackInviteHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/AcceptBackpackInviteHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.User.Api.CommandHandlers;
 using DeUrgenta.User.Api.Commands;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.User.Api.Tests.CommandHandlers
             var result = await sut.Handle(new AcceptBackpackInvite("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/AcceptGroupInviteHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/AcceptGroupInviteHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.User.Api.CommandHandlers;
 using DeUrgenta.User.Api.Commands;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.User.Api.Tests.CommandHandlers
             var result = await sut.Handle(new AcceptGroupInvite("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/AddLocationHandler.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/AddLocationHandler.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.User.Api.CommandHandlers;
 using DeUrgenta.User.Api.Commands;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.User.Api.Tests.CommandHandlers
             var result = await sut.Handle(new AcceptGroupInvite("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/DeleteLocationHandler.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/DeleteLocationHandler.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.User.Api.CommandHandlers;
 using DeUrgenta.User.Api.Commands;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.User.Api.Tests.CommandHandlers
             var result = await sut.Handle(new AcceptGroupInvite("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/RejectBackpackInviteHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/RejectBackpackInviteHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.User.Api.CommandHandlers;
 using DeUrgenta.User.Api.Commands;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.User.Api.Tests.CommandHandlers
             var result = await sut.Handle(new RejectBackpackInvite("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/RejectGroupInviteHandler.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/RejectGroupInviteHandler.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.User.Api.CommandHandlers;
 using DeUrgenta.User.Api.Commands;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.User.Api.Tests.CommandHandlers
             var result = await sut.Handle(new RejectGroupInvite("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/UpdateLocationHandler.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/UpdateLocationHandler.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.User.Api.CommandHandlers;
 using DeUrgenta.User.Api.Commands;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.User.Api.Tests.CommandHandlers
             var result = await sut.Handle(new AcceptGroupInvite("a-sub", Guid.NewGuid()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/UpdateUserHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/CommandHandlers/UpdateUserHandlerShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.User.Api.CommandHandlers;
 using DeUrgenta.User.Api.Commands;
 using DeUrgenta.User.Api.Models;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.CommandHandlers
@@ -37,7 +37,7 @@ namespace DeUrgenta.User.Api.Tests.CommandHandlers
             var result = await sut.Handle(new UpdateUser("a-sub", new UserRequest()), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/DeUrgenta.User.Api.Tests.csproj
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/DeUrgenta.User.Api.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.14" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/Tests/DeUrgenta.User.Api.Tests/QueryHandlers/GetBackpackInvitesHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/QueryHandlers/GetBackpackInvitesHandlerShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.User.Api.Queries;
 using DeUrgenta.User.Api.QueryHandlers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.QueryHandlers
@@ -36,7 +36,7 @@ namespace DeUrgenta.User.Api.Tests.QueryHandlers
             var result = await sut.Handle(new GetBackpackInvites("a-sub"), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/QueryHandlers/GetGroupInvitesHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/QueryHandlers/GetGroupInvitesHandlerShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.User.Api.Queries;
 using DeUrgenta.User.Api.QueryHandlers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.QueryHandlers
@@ -36,7 +36,7 @@ namespace DeUrgenta.User.Api.Tests.QueryHandlers
             var result = await sut.Handle(new GetGroupInvites("a-sub"), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/QueryHandlers/GetUserHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/QueryHandlers/GetUserHandlerShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.User.Api.Queries;
 using DeUrgenta.User.Api.QueryHandlers;
 using NSubstitute;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.QueryHandlers
@@ -36,7 +36,7 @@ namespace DeUrgenta.User.Api.Tests.QueryHandlers
             var result = await sut.Handle(new GetUser("a-sub"), CancellationToken.None);
 
             // Assert
-            result.IsFailure.ShouldBeTrue();
+            result.IsFailure.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/Validators/AcceptBackpackInviteValidator.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/Validators/AcceptBackpackInviteValidator.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
 using DeUrgenta.User.Api.Commands;
 using DeUrgenta.User.Api.Validators;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AcceptBackpackInvite(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AcceptBackpackInvite(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AcceptBackpackInvite(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -146,7 +146,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AcceptBackpackInvite(userSub, backpackInvite.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/Validators/AcceptGroupInviteValidator.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/Validators/AcceptGroupInviteValidator.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
 using DeUrgenta.User.Api.Commands;
 using DeUrgenta.User.Api.Validators;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AcceptGroupInvite(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AcceptGroupInvite(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -110,7 +110,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AcceptGroupInvite(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -149,7 +149,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AcceptGroupInvite(userSub, groupInvite.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/Validators/AddLocationValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/Validators/AddLocationValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Tests.Helpers.Builders;
 using DeUrgenta.User.Api.Commands;
 using DeUrgenta.User.Api.Models;
 using DeUrgenta.User.Api.Validators;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AddLocation(sub, new UserLocationRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new AddLocation(userSub, new UserLocationRequest()));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/Validators/DeleteLocationValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/Validators/DeleteLocationValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
 using DeUrgenta.User.Api.Commands;
 using DeUrgenta.User.Api.Validators;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteLocation(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteLocation(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -84,7 +84,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new DeleteLocation(userSub, userLocation.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/Validators/GetBackpackInvitesValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/Validators/GetBackpackInvitesValidatorShould.cs
@@ -5,7 +5,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
 using DeUrgenta.User.Api.Queries;
 using DeUrgenta.User.Api.Validators;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.Validators
@@ -33,7 +33,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetBackpackInvites(sub));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetBackpackInvites(userSub));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/Validators/GetGroupInvitesValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/Validators/GetGroupInvitesValidatorShould.cs
@@ -5,7 +5,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
 using DeUrgenta.User.Api.Queries;
 using DeUrgenta.User.Api.Validators;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.Validators
@@ -33,7 +33,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetGroupInvites(sub));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetGroupInvites(userSub));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/Validators/GetUserLocationsValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/Validators/GetUserLocationsValidatorShould.cs
@@ -5,7 +5,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
 using DeUrgenta.User.Api.Queries;
 using DeUrgenta.User.Api.Validators;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.Validators
@@ -33,7 +33,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetUserLocations(sub));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetUserLocations(userSub));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/Validators/GetUserValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/Validators/GetUserValidatorShould.cs
@@ -5,7 +5,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
 using DeUrgenta.User.Api.Queries;
 using DeUrgenta.User.Api.Validators;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.Validators
@@ -33,7 +33,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetUser(sub));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new GetUser(userSub));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/Validators/RejectBackpackInviteValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/Validators/RejectBackpackInviteValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
 using DeUrgenta.User.Api.Commands;
 using DeUrgenta.User.Api.Validators;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RejectBackpackInvite(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RejectBackpackInvite(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RejectBackpackInvite(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -146,7 +146,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RejectBackpackInvite(userSub, backpackInvite.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/Validators/RejectGroupInviteValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/Validators/RejectGroupInviteValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
 using DeUrgenta.User.Api.Commands;
 using DeUrgenta.User.Api.Validators;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RejectGroupInvite(sub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RejectGroupInvite(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -110,7 +110,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RejectGroupInvite(userSub, Guid.NewGuid()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -149,7 +149,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new RejectGroupInvite(userSub, groupInvite.Id));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/Validators/UpdateLocationValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/Validators/UpdateLocationValidatorShould.cs
@@ -7,7 +7,7 @@ using DeUrgenta.Tests.Helpers.Builders;
 using DeUrgenta.User.Api.Commands;
 using DeUrgenta.User.Api.Models;
 using DeUrgenta.User.Api.Validators;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.Validators
@@ -35,7 +35,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateLocation(sub, Guid.NewGuid(), new UserLocationRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateLocation(userSub, Guid.NewGuid(), new UserLocationRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateLocation(userSub, userLocation.Id, new UserLocationRequest()));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/Validators/UpdateUserValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/Validators/UpdateUserValidatorShould.cs
@@ -6,7 +6,7 @@ using DeUrgenta.Tests.Helpers.Builders;
 using DeUrgenta.User.Api.Commands;
 using DeUrgenta.User.Api.Models;
 using DeUrgenta.User.Api.Validators;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.Validators
@@ -34,7 +34,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateUser(sub, new UserRequest()));
 
             // Assert
-            isValid.ShouldBeFalse();
+            isValid.Should().BeFalse();
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             var isValid = await sut.IsValidAsync(new UpdateUser(userSub, new UserRequest()));
 
             // Assert
-            isValid.ShouldBeTrue();
+            isValid.Should().BeTrue();
         }
     }
 }


### PR DESCRIPTION
### What does it fix?

Closes #109 

- [x] Remove Shouldly from all test projects
- [x] Add FluentAssertions to all test projects
- [x] Rewrite assertions using FluentAssertions

### How has it been tested?

Ran the entire test suite successfully. Also checked if FluentAssertions works as intended.