### PR TITLE
Add group users limit verification

### DIFF
--- a/Src/DeUrgenta.Api/Startup.cs
+++ b/Src/DeUrgenta.Api/Startup.cs
@@ -46,7 +46,7 @@ namespace DeUrgenta.Api
             services.AddDatabase<DeUrgentaContext>(Configuration.GetConnectionString("DbConnectionString"));
             services.AddExceptionHandling(WebHostEnvironment);
 
-            services.AddUserApiServices();
+            services.AddUserApiServices(Configuration);
             services.AddBackpackApiServices();
             services.AddGroupApiServices(Configuration);
             services.AddCertificationsApiServices();         

--- a/Src/DeUrgenta.Api/appsettings.json
+++ b/Src/DeUrgenta.Api/appsettings.json
@@ -47,7 +47,8 @@
   },
   "Group": {
     "MaxJoinedGroupsPerUser": 5,
-    "MaxCreatedGroupsPerUser": 5
+    "MaxCreatedGroupsPerUser": 5,
+    "UsersLimit": 30
   },
   "Passwords": {
     "RequiredLength": 6,

--- a/Src/DeUrgenta.User.Api/BootstrappingExtensions.cs
+++ b/Src/DeUrgenta.User.Api/BootstrappingExtensions.cs
@@ -116,8 +116,10 @@ namespace DeUrgenta.User.Api
             }
         }
 
-        public static IServiceCollection AddUserApiServices(this IServiceCollection services)
+        public static IServiceCollection AddUserApiServices(this IServiceCollection services, IConfiguration configuration)
         {
+            services.Configure<GroupsConfig>(configuration.GetSection(GroupsConfig.SectionName));
+            
             services.AddTransient<IValidateRequest<GetUser>, GetUserValidator>();
             services.AddTransient<IValidateRequest<UpdateUser>, UpdateUserValidator>();
             services.AddTransient<IValidateRequest<GetBackpackInvites>, GetBackpackInvitesValidator>();

--- a/Src/DeUrgenta.User.Api/Options/GroupsConfig.cs
+++ b/Src/DeUrgenta.User.Api/Options/GroupsConfig.cs
@@ -1,0 +1,8 @@
+﻿namespace DeUrgenta.User.Api.Options
+{
+    public class GroupsConfig
+    {
+        public const string SectionName = "Group";
+        public int UsersLimit { get; set; }
+    }
+}

--- a/Src/DeUrgenta.User.Api/Validators/AcceptGroupInviteValidator.cs
+++ b/Src/DeUrgenta.User.Api/Validators/AcceptGroupInviteValidator.cs
@@ -1,18 +1,23 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.User.Api.Commands;
+using DeUrgenta.User.Api.Options;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace DeUrgenta.User.Api.Validators
 {
     public class AcceptGroupInviteValidator : IValidateRequest<AcceptGroupInvite>
     {
         private readonly DeUrgentaContext _context;
+        private readonly IOptions<GroupsConfig> _options;
 
-        public AcceptGroupInviteValidator(DeUrgentaContext context)
+        public AcceptGroupInviteValidator(DeUrgentaContext context, IOptions<GroupsConfig> options)
         {
             _context = context;
+            _options = options;
         }
 
         public async Task<bool> IsValidAsync(AcceptGroupInvite request)
@@ -24,11 +29,29 @@ namespace DeUrgenta.User.Api.Validators
                 return false;
             }
 
-            var inviteExists = await _context
+            var invite = await _context
                 .GroupInvites
-                .AnyAsync(bi => bi.InvitationReceiver.Sub == request.UserSub && bi.Id == request.GroupInviteId);
+                .FirstOrDefaultAsync(bi => bi.InvitationReceiver.Sub == request.UserSub && bi.Id == request.GroupInviteId);
 
-            return inviteExists;
+            if (invite is null)
+            {
+                return false;
+            }
+
+            var config = _options.Value;
+            
+            var exceedsLimit = await _context.UsersToGroups
+                .Where(x => x.GroupId == invite.GroupId)
+                .GroupBy(x => x.GroupId)
+                .Where(g => g.Count() >= config.UsersLimit)
+                .AnyAsync();
+            
+            if (exceedsLimit)
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/Src/Tests/DeUrgenta.User.Api.Tests/Validators/AcceptGroupInviteValidator.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/Validators/AcceptGroupInviteValidator.cs
@@ -5,8 +5,11 @@ using DeUrgenta.Domain.Entities;
 using DeUrgenta.Tests.Helpers;
 using DeUrgenta.Tests.Helpers.Builders;
 using DeUrgenta.User.Api.Commands;
+using DeUrgenta.User.Api.Options;
 using DeUrgenta.User.Api.Validators;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
 using Xunit;
 
 namespace DeUrgenta.User.Api.Tests.Validators
@@ -15,10 +18,11 @@ namespace DeUrgenta.User.Api.Tests.Validators
     public class AcceptGroupInviteValidatorShould
     {
         private readonly DeUrgentaContext _dbContext;
-
+        private readonly IOptions<GroupsConfig> _defaultOptions = Substitute.For<IOptions<GroupsConfig>>();
         public AcceptGroupInviteValidatorShould(DatabaseFixture fixture)
         {
             _dbContext = fixture.Context;
+            _defaultOptions.Value.Returns(new GroupsConfig { UsersLimit = 30 });
         }
 
         [Theory]
@@ -28,7 +32,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
         public async Task Invalidate_request_when_no_user_found_by_sub(string sub)
         {
             // Arrange
-            var sut = new AcceptGroupInviteValidator(_dbContext);
+            var sut = new AcceptGroupInviteValidator(_dbContext, _defaultOptions);
 
             // Act
             var isValid = await sut.IsValidAsync(new AcceptGroupInvite(sub, Guid.NewGuid()));
@@ -40,7 +44,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
         [Fact]
         public async Task Invalidate_when_invite_is_for_other_user()
         {
-            var sut = new AcceptGroupInviteValidator(_dbContext);
+            var sut = new AcceptGroupInviteValidator(_dbContext, _defaultOptions);
 
             // Arrange
             var userSub = Guid.NewGuid().ToString();
@@ -84,7 +88,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
         [Fact]
         public async Task Invalidate_when_invite_does_not_exist()
         {
-            var sut = new AcceptGroupInviteValidator(_dbContext);
+            var sut = new AcceptGroupInviteValidator(_dbContext, _defaultOptions);
 
             // Arrange
             var userSub = Guid.NewGuid().ToString();
@@ -114,9 +118,56 @@ namespace DeUrgenta.User.Api.Tests.Validators
         }
 
         [Fact]
+        public async Task Invalidate_when_exceeds_group_users_limit()
+        {
+            var options = Substitute.For<IOptions<GroupsConfig>>();
+            options.Value.Returns(new GroupsConfig { UsersLimit = 2 });
+            var sut = new AcceptGroupInviteValidator(_dbContext, options);
+
+            // Arrange
+            var userSub = Guid.NewGuid().ToString();
+            var user = new UserBuilder().WithSub(userSub).Build();
+            
+            var secondUserSub = Guid.NewGuid().ToString();
+            var secondUser = new UserBuilder().WithSub(secondUserSub).Build();
+            
+            var adminSub = Guid.NewGuid().ToString();
+            var admin = new UserBuilder().WithSub(adminSub).Build();
+
+            await _dbContext.Users.AddAsync(user);
+            await _dbContext.Users.AddAsync(admin);
+
+            var group = new Group
+            {
+                Admin = admin,
+                Name = "group"
+            };
+
+            await _dbContext.UsersToGroups.AddAsync(new UserToGroup { Group = group, User = admin });
+            await _dbContext.UsersToGroups.AddAsync(new UserToGroup { Group = group, User = user });
+            
+            var groupInvite = new GroupInvite
+            {
+                InvitationReceiver = secondUser,
+                InvitationSender = admin,
+                Group = group
+            };
+            await _dbContext.GroupInvites.AddAsync(groupInvite);
+            await _dbContext.Groups.AddAsync(group);
+
+            await _dbContext.SaveChangesAsync();
+
+            // Act
+            var isValid = await sut.IsValidAsync(new AcceptGroupInvite(secondUserSub, groupInvite.Id));
+
+            // Assert
+            isValid.Should().BeFalse();
+        }
+        
+        [Fact]
         public async Task Validate_when_an_invite_exists()
         {
-            var sut = new AcceptGroupInviteValidator(_dbContext);
+            var sut = new AcceptGroupInviteValidator(_dbContext, _defaultOptions);
 
             // Arrange
             var userSub = Guid.NewGuid().ToString();


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?

Closes #98  

<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

<!-- Please describe the tests that you ran to verify your changes. -->
I have added new test to `AcceptGroupInviteValidator` making sure that user cannot accept invitation when the limit is exceeded.

<!-- If applicable, mention any known issues with the pull request -->

I am not sure, but I think there is bug in `DeUrgenta.Group.Api.GroupsConfig`. Property `SectionName` has value `"Groups"` whereas in `DeUrgenta.Api.appsettings.json` section is named `"Group"`