### PR TITLE
Added max number of users to GroupModel

### DIFF
--- a/Src/DeUrgenta.Group.Api/CommandHandlers/UpdateGroupHandler.cs
+++ b/Src/DeUrgenta.Group.Api/CommandHandlers/UpdateGroupHandler.cs
@@ -5,8 +5,10 @@ using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Group.Api.Models;
+using DeUrgenta.Group.Api.Options;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace DeUrgenta.Group.Api.CommandHandlers
 {
@@ -14,11 +16,14 @@ namespace DeUrgenta.Group.Api.CommandHandlers
     {
         private readonly IValidateRequest<UpdateGroup> _validator;
         private readonly DeUrgentaContext _context;
+        private readonly GroupsConfig _groupsConfig;
 
-        public UpdateGroupHandler(IValidateRequest<UpdateGroup> validator, DeUrgentaContext context)
+        public UpdateGroupHandler(IValidateRequest<UpdateGroup> validator, DeUrgentaContext context,
+            IOptions<GroupsConfig> groupsConfig)
         {
             _validator = validator;
             _context = context;
+            _groupsConfig = groupsConfig.Value;
         }
 
         public async Task<Result<GroupModel>> Handle(UpdateGroup request, CancellationToken cancellationToken)
@@ -44,6 +49,7 @@ namespace DeUrgenta.Group.Api.CommandHandlers
                 Id = group.Id,
                 Name = group.Name,
                 NumberOfMembers = group.GroupMembers.Count,
+                MaxNumberOfMembers = _groupsConfig.UsersLimit,
                 AdminId = group.AdminId,
                 AdminFirstName = group.Admin.FirstName,
                 AdminLastName = group.Admin.LastName

--- a/Src/DeUrgenta.Group.Api/Models/GroupModel.cs
+++ b/Src/DeUrgenta.Group.Api/Models/GroupModel.cs
@@ -7,6 +7,7 @@ namespace DeUrgenta.Group.Api.Models
         public Guid Id { get; init; }
         public string Name { get; init; }
         public int NumberOfMembers { get; set; }
+        public int MaxNumberOfMembers { get; set; }
         public Guid AdminId { get; set; }
         public string AdminFirstName { get; set; }
         public string AdminLastName { get; set; }

--- a/Src/DeUrgenta.Group.Api/Options/GroupsConfig.cs
+++ b/Src/DeUrgenta.Group.Api/Options/GroupsConfig.cs
@@ -3,8 +3,9 @@ namespace DeUrgenta.Group.Api.Options
     public class GroupsConfig
     {
         public const string SectionName = "Groups";
-        
+
         public int MaxJoinedGroupsPerUser { get; set; }
         public int MaxCreatedGroupsPerUser { get; set; }
+        public int UsersLimit { get; set; }
     }
 }

--- a/Src/DeUrgenta.Group.Api/QueryHandlers/GetMyGroupsHandler.cs
+++ b/Src/DeUrgenta.Group.Api/QueryHandlers/GetMyGroupsHandler.cs
@@ -6,9 +6,11 @@ using CSharpFunctionalExtensions;
 using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Group.Api.Models;
+using DeUrgenta.Group.Api.Options;
 using DeUrgenta.Group.Api.Queries;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace DeUrgenta.Group.Api.QueryHandlers
 {
@@ -16,14 +18,18 @@ namespace DeUrgenta.Group.Api.QueryHandlers
     {
         private readonly IValidateRequest<GetMyGroups> _validator;
         private readonly DeUrgentaContext _context;
+        private readonly GroupsConfig _groupsConfig;
 
-        public GetMyGroupsHandler(IValidateRequest<GetMyGroups> validator, DeUrgentaContext context)
+        public GetMyGroupsHandler(IValidateRequest<GetMyGroups> validator, DeUrgentaContext context,
+            IOptions<GroupsConfig> groupsConfig)
         {
             _validator = validator;
             _context = context;
+            _groupsConfig = groupsConfig.Value;
         }
 
-        public async Task<Result<IImmutableList<GroupModel>>> Handle(GetMyGroups request, CancellationToken cancellationToken)
+        public async Task<Result<IImmutableList<GroupModel>>> Handle(GetMyGroups request,
+            CancellationToken cancellationToken)
         {
             var isValid = await _validator.IsValidAsync(request);
 
@@ -45,6 +51,7 @@ namespace DeUrgenta.Group.Api.QueryHandlers
                     Id = g.Id,
                     Name = g.Name,
                     NumberOfMembers = g.GroupMembers.Count,
+                    MaxNumberOfMembers = _groupsConfig.UsersLimit,
                     AdminId = g.AdminId,
                     AdminFirstName = g.Admin.FirstName,
                     AdminLastName = g.Admin.LastName

--- a/Src/DeUrgenta.Group.Api/Validators/AddGroupValidator.cs
+++ b/Src/DeUrgenta.Group.Api/Validators/AddGroupValidator.cs
@@ -13,12 +13,6 @@ namespace DeUrgenta.Group.Api.Validators
         private readonly DeUrgentaContext _context;
         private readonly GroupsConfig _groupsConfig;
 
-        public AddGroupValidator(DeUrgentaContext context, GroupsConfig groupsConfig)
-        {
-            _context = context;
-            _groupsConfig = groupsConfig;
-        }
-        
         public AddGroupValidator(DeUrgentaContext context, IOptions<GroupsConfig> groupsConfig)
         {
             _context = context;
@@ -32,7 +26,7 @@ namespace DeUrgenta.Group.Api.Validators
             {
                 return false;
             }
-            
+
             if (user.GroupsAdministered.Count >= _groupsConfig.MaxCreatedGroupsPerUser)
             {
                 return false;

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/AddGroupHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/AddGroupHandlerShould.cs
@@ -1,13 +1,17 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
 using DeUrgenta.Group.Api.CommandHandlers;
 using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Group.Api.Models;
+using DeUrgenta.Group.Api.Options;
 using DeUrgenta.Tests.Helpers;
+using DeUrgenta.Tests.Helpers.Builders;
 using NSubstitute;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
@@ -16,10 +20,13 @@ namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
     public class AddGroupHandlerShould
     {
         private readonly DeUrgentaContext _dbContext;
+        private readonly IOptions<GroupsConfig> _groupsConfig;
 
         public AddGroupHandlerShould(DatabaseFixture fixture)
         {
             _dbContext = fixture.Context;
+            var options = new GroupsConfig {UsersLimit = 35};
+            _groupsConfig = Microsoft.Extensions.Options.Options.Create<GroupsConfig>(options);
         }
 
         [Fact]
@@ -31,13 +38,39 @@ namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
                 .IsValidAsync(Arg.Any<AddGroup>())
                 .Returns(Task.FromResult(false));
 
-            var sut = new AddGroupHandler(validator, _dbContext);
+            var sut = new AddGroupHandler(validator, _dbContext, _groupsConfig);
 
             // Act
             var result = await sut.Handle(new AddGroup("a-sub", new GroupRequest()), CancellationToken.None);
 
             // Assert
             result.IsFailure.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Return_max_number_of_users()
+        {
+            // Arrange
+            var validator = Substitute.For<IValidateRequest<AddGroup>>();
+            validator
+                .IsValidAsync(Arg.Any<AddGroup>())
+                .Returns(Task.FromResult(true));
+
+            var userId = Guid.NewGuid();
+            var userSub = TestDataProviders.RandomString();
+            var user = new UserBuilder().WithId(userId).WithSub(userSub).Build();
+            await _dbContext.Users.AddAsync(user);
+            await _dbContext.SaveChangesAsync();
+
+            var sut = new AddGroupHandler(validator, _dbContext, _groupsConfig);
+
+            // Act
+            var result =
+                await sut.Handle(new AddGroup(userSub, new GroupRequest {Name = TestDataProviders.RandomString()}),
+                    CancellationToken.None);
+
+            // Assert
+            result.Value.MaxNumberOfMembers.Should().Be(35);
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/UpdateGroupHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/CommandsHandlers/UpdateGroupHandlerShould.cs
@@ -6,9 +6,12 @@ using DeUrgenta.Domain;
 using DeUrgenta.Group.Api.CommandHandlers;
 using DeUrgenta.Group.Api.Commands;
 using DeUrgenta.Group.Api.Models;
+using DeUrgenta.Group.Api.Options;
 using DeUrgenta.Tests.Helpers;
+using DeUrgenta.Tests.Helpers.Builders;
 using NSubstitute;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
@@ -17,10 +20,13 @@ namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
     public class UpdateGroupHandlerShould
     {
         private readonly DeUrgentaContext _dbContext;
+        private readonly IOptions<GroupsConfig> _groupsConfig;
 
         public UpdateGroupHandlerShould(DatabaseFixture fixture)
         {
             _dbContext = fixture.Context;
+            var options = new GroupsConfig {UsersLimit = 35};
+            _groupsConfig = Microsoft.Extensions.Options.Options.Create<GroupsConfig>(options);
         }
 
         [Fact]
@@ -32,13 +38,45 @@ namespace DeUrgenta.Group.Api.Tests.CommandsHandlers
                 .IsValidAsync(Arg.Any<UpdateGroup>())
                 .Returns(Task.FromResult(false));
 
-            var sut = new UpdateGroupHandler(validator, _dbContext);
+            var sut = new UpdateGroupHandler(validator, _dbContext, _groupsConfig);
 
             // Act
-            var result = await sut.Handle(new UpdateGroup("a-sub", Guid.NewGuid(), new GroupRequest()), CancellationToken.None);
+            var result = await sut.Handle(new UpdateGroup("a-sub", Guid.NewGuid(), new GroupRequest()),
+                CancellationToken.None);
 
             // Assert
             result.IsFailure.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Return_max_number_of_users()
+        {
+            // Arrange
+            var validator = Substitute.For<IValidateRequest<UpdateGroup>>();
+            validator
+                .IsValidAsync(Arg.Any<UpdateGroup>())
+                .Returns(Task.FromResult(true));
+
+            var userId = Guid.NewGuid();
+            var userSub = TestDataProviders.RandomString();
+            var user = new UserBuilder().WithId(userId).WithSub(userSub).Build();
+            await _dbContext.Users.AddAsync(user);
+            await _dbContext.SaveChangesAsync();
+
+            var group = new GroupBuilder().WithAdmin(user).Build();
+            await _dbContext.Groups.AddAsync(group);
+            await _dbContext.SaveChangesAsync();
+
+            var sut = new UpdateGroupHandler(validator, _dbContext, _groupsConfig);
+
+            // Act
+            var result =
+                await sut.Handle(
+                    new UpdateGroup(userSub, group.Id, new GroupRequest {Name = TestDataProviders.RandomString()}),
+                    CancellationToken.None);
+
+            // Assert
+            result.Value.MaxNumberOfMembers.Should().Be(35);
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/QueriesHandlers/GetAdministeredGroupsHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/QueriesHandlers/GetAdministeredGroupsHandlerShould.cs
@@ -1,12 +1,17 @@
-﻿using System.Threading;
+﻿using System;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
+using DeUrgenta.Group.Api.Options;
 using DeUrgenta.Group.Api.Queries;
 using DeUrgenta.Group.Api.QueryHandlers;
 using DeUrgenta.Tests.Helpers;
+using DeUrgenta.Tests.Helpers.Builders;
 using NSubstitute;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.QueriesHandlers
@@ -15,10 +20,13 @@ namespace DeUrgenta.Group.Api.Tests.QueriesHandlers
     public class GetAdministeredGroupsHandlerShould
     {
         private readonly DeUrgentaContext _dbContext;
+        private readonly IOptions<GroupsConfig> _groupsConfig;
 
         public GetAdministeredGroupsHandlerShould(DatabaseFixture fixture)
         {
             _dbContext = fixture.Context;
+            var options = new GroupsConfig {UsersLimit = 35};
+            _groupsConfig = Microsoft.Extensions.Options.Options.Create<GroupsConfig>(options);
         }
 
         [Fact]
@@ -30,13 +38,41 @@ namespace DeUrgenta.Group.Api.Tests.QueriesHandlers
                 .IsValidAsync(Arg.Any<GetAdministeredGroups>())
                 .Returns(Task.FromResult(false));
 
-            var sut = new GetAdministeredGroupsHandler(validator, _dbContext);
+            var sut = new GetAdministeredGroupsHandler(validator, _dbContext, _groupsConfig);
 
             // Act
             var result = await sut.Handle(new GetAdministeredGroups("a-sub"), CancellationToken.None);
 
             // Assert
             result.IsFailure.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Return_max_number_of_users()
+        {
+            // Arrange
+            var validator = Substitute.For<IValidateRequest<GetAdministeredGroups>>();
+            validator
+                .IsValidAsync(Arg.Any<GetAdministeredGroups>())
+                .Returns(Task.FromResult(true));
+
+            var userId = Guid.NewGuid();
+            var userSub = TestDataProviders.RandomString();
+            var user = new UserBuilder().WithId(userId).WithSub(userSub).Build();
+            await _dbContext.Users.AddAsync(user);
+            await _dbContext.SaveChangesAsync();
+
+            var group = new GroupBuilder().WithAdmin(user).Build();
+            await _dbContext.Groups.AddAsync(group);
+            await _dbContext.SaveChangesAsync();
+
+            var sut = new GetAdministeredGroupsHandler(validator, _dbContext, _groupsConfig);
+
+            // Act
+            var result = await sut.Handle(new GetAdministeredGroups(userSub), CancellationToken.None);
+
+            // Assert
+            result.Value.Where(g => g.Id.Equals(group.Id)).First().MaxNumberOfMembers.Should().Be(35);
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/QueriesHandlers/GetMyGroupsHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/QueriesHandlers/GetMyGroupsHandlerShould.cs
@@ -1,12 +1,18 @@
-﻿using System.Threading;
+﻿using System;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain;
+using DeUrgenta.Domain.Entities;
+using DeUrgenta.Group.Api.Options;
 using DeUrgenta.Group.Api.Queries;
 using DeUrgenta.Group.Api.QueryHandlers;
 using DeUrgenta.Tests.Helpers;
+using DeUrgenta.Tests.Helpers.Builders;
 using NSubstitute;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace DeUrgenta.Group.Api.Tests.QueriesHandlers
@@ -15,10 +21,13 @@ namespace DeUrgenta.Group.Api.Tests.QueriesHandlers
     public class GetMyGroupsHandlerShould
     {
         private readonly DeUrgentaContext _dbContext;
+        private readonly IOptions<GroupsConfig> _groupsConfig;
 
         public GetMyGroupsHandlerShould(DatabaseFixture fixture)
         {
             _dbContext = fixture.Context;
+            var options = new GroupsConfig {UsersLimit = 35};
+            _groupsConfig = Microsoft.Extensions.Options.Options.Create<GroupsConfig>(options);
         }
 
         [Fact]
@@ -30,13 +39,45 @@ namespace DeUrgenta.Group.Api.Tests.QueriesHandlers
                 .IsValidAsync(Arg.Any<GetMyGroups>())
                 .Returns(Task.FromResult(false));
 
-            var sut = new GetMyGroupsHandler(validator, _dbContext);
+            var sut = new GetMyGroupsHandler(validator, _dbContext, _groupsConfig);
 
             // Act
             var result = await sut.Handle(new GetMyGroups("a-sub"), CancellationToken.None);
 
             // Assert
             result.IsFailure.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Return_max_number_of_users()
+        {
+            // Arrange
+            var validator = Substitute.For<IValidateRequest<GetMyGroups>>();
+            validator
+                .IsValidAsync(Arg.Any<GetMyGroups>())
+                .Returns(Task.FromResult(true));
+
+            var userId = Guid.NewGuid();
+            var userSub = TestDataProviders.RandomString();
+            var user = new UserBuilder().WithId(userId).WithSub(userSub).Build();
+            await _dbContext.Users.AddAsync(user);
+            await _dbContext.SaveChangesAsync();
+
+            var group = new GroupBuilder().WithAdmin(user).Build();
+            await _dbContext.Groups.AddAsync(group);
+            await _dbContext.SaveChangesAsync();
+
+            var userToGroup = new UserToGroup {User = user, Group = group};
+            await _dbContext.UsersToGroups.AddAsync(userToGroup);
+            await _dbContext.SaveChangesAsync();
+
+            var sut = new GetMyGroupsHandler(validator, _dbContext, _groupsConfig);
+
+            // Act
+            var result = await sut.Handle(new GetMyGroups(userSub), CancellationToken.None);
+
+            // Assert
+            result.Value.Where(g => g.Id.Equals(group.Id)).First().MaxNumberOfMembers.Should().Be(35);
         }
     }
 }

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/AddSafeLocationValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/AddSafeLocationValidatorShould.cs
@@ -51,7 +51,8 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var sut = new AddSafeLocationValidator(_dbContext);
 
             // Act
-            var isValid = await sut.IsValidAsync(new AddSafeLocation(userSub, Guid.NewGuid(), new SafeLocationRequest()));
+            var isValid =
+                await sut.IsValidAsync(new AddSafeLocation(userSub, Guid.NewGuid(), new SafeLocationRequest()));
 
             // Assert
             isValid.Should().BeFalse();
@@ -69,7 +70,8 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var sut = new AddSafeLocationValidator(_dbContext);
 
             // Act
-            var isValid = await sut.IsValidAsync(new AddSafeLocation(userSub, Guid.NewGuid(), new SafeLocationRequest()));
+            var isValid =
+                await sut.IsValidAsync(new AddSafeLocation(userSub, Guid.NewGuid(), new SafeLocationRequest()));
 
             // Assert
             isValid.Should().BeFalse();
@@ -85,11 +87,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var user = new UserBuilder().WithSub(userSub).Build();
             var adminUser = new UserBuilder().WithSub(adminSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = adminUser,
-                Name = "a group"
-            };
+            var group = new GroupBuilder().WithAdmin(adminUser).Build();
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Users.AddAsync(adminUser);
@@ -99,7 +97,8 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var sut = new AddSafeLocationValidator(_dbContext);
 
             // Act
-            var isValid = await sut.IsValidAsync(new AddSafeLocation(userSub, Guid.NewGuid(), new SafeLocationRequest()));
+            var isValid =
+                await sut.IsValidAsync(new AddSafeLocation(userSub, Guid.NewGuid(), new SafeLocationRequest()));
 
             // Assert
             isValid.Should().BeFalse();
@@ -114,11 +113,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var userSub = Guid.NewGuid().ToString();
             var user = new UserBuilder().WithSub(userSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = user,
-                Name = "my group"
-            };
+            var group = new GroupBuilder().WithAdmin(user).Build();
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Groups.AddAsync(group);
             await _dbContext.SaveChangesAsync();

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/DeleteGroupValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/DeleteGroupValidatorShould.cs
@@ -65,11 +65,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var user = new UserBuilder().WithSub(userSub).Build();
             var adminUser = new UserBuilder().WithSub(adminSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = adminUser,
-                Name = "a group"
-            };
+            var group = new GroupBuilder().WithAdmin(adminUser).Build();
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Users.AddAsync(adminUser);
@@ -94,11 +90,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var userSub = Guid.NewGuid().ToString();
             var user = new UserBuilder().WithSub(userSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = user,
-                Name = "my group"
-            };
+            var group = new GroupBuilder().WithAdmin(user).Build();
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Groups.AddAsync(group);
             await _dbContext.SaveChangesAsync();

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/DeleteSafeLocationValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/DeleteSafeLocationValidatorShould.cs
@@ -85,17 +85,9 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var user = new UserBuilder().WithSub(userSub).Build();
             var adminUser = new UserBuilder().WithSub(adminSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = adminUser,
-                Name = "a group"
-            };
+            var group = new GroupBuilder().WithAdmin(adminUser).Build();
 
-            var groupSafeLocation = new GroupSafeLocation
-            {
-                Group = group,
-                Name = "A safe location"
-            };
+            var groupSafeLocation = new GroupSafeLocation {Group = group, Name = "A safe location"};
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Users.AddAsync(adminUser);
@@ -121,17 +113,9 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var userSub = Guid.NewGuid().ToString();
             var user = new UserBuilder().WithSub(userSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = user,
-                Name = "my group"
-            };
+            var group = new GroupBuilder().WithAdmin(user).Build();
 
-            var groupSafeLocation = new GroupSafeLocation
-            {
-                Group = group,
-                Name = "A safe location"
-            };
+            var groupSafeLocation = new GroupSafeLocation {Group = group, Name = "A safe location"};
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Groups.AddAsync(group);

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/GetGroupMembersValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/GetGroupMembersValidatorShould.cs
@@ -63,7 +63,8 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var user = new UserBuilder().WithSub(userSub).Build();
             var adminUser = new UserBuilder().Build();
 
-            var group = new Domain.Entities.Group { Admin = adminUser, Name = "A group" };
+            var group = new GroupBuilder().WithAdmin(adminUser).Build();
+            ;
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Groups.AddAsync(group);
@@ -88,9 +89,10 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var user = new UserBuilder().WithSub(userSub).Build();
             var adminUser = new UserBuilder().WithSub(adminSub).Build();
 
-            var group = new Domain.Entities.Group { Admin = adminUser, Name = "A group" };
+            var group = new GroupBuilder().WithAdmin(adminUser).Build();
+            ;
 
-            var userToGroup = new UserToGroup { User = user, Group = group};
+            var userToGroup = new UserToGroup {User = user, Group = group};
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Groups.AddAsync(group);
@@ -114,9 +116,9 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var userSub = Guid.NewGuid().ToString();
             var user = new UserBuilder().WithSub(userSub).Build();
 
-            var group = new Domain.Entities.Group { Admin = user, Name = "A group" };
+            var group = new GroupBuilder().WithAdmin(user).Build();
 
-            var userToGroup = new UserToGroup { User = user, Group = group };
+            var userToGroup = new UserToGroup {User = user, Group = group};
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Groups.AddAsync(group);

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/GetGroupSafeLocationsValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/GetGroupSafeLocationsValidatorShould.cs
@@ -66,13 +66,9 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var user = new UserBuilder().WithSub(userSub).Build();
             var admin = new UserBuilder().WithSub(adminSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = admin,
-                Name = "A group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
-            var adminToGroup = new UserToGroup { Group = group, User = admin };
+            var adminToGroup = new UserToGroup {Group = group, User = admin};
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Groups.AddAsync(group);
@@ -97,12 +93,8 @@ namespace DeUrgenta.Group.Api.Tests.Validators
 
             var user = new UserBuilder().WithSub(userSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = user,
-                Name = "A group"
-            };
-            var userToGroup = new UserToGroup { Group = group, User = user };
+            var group = new GroupBuilder().WithAdmin(user).Build();
+            var userToGroup = new UserToGroup {Group = group, User = user};
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Groups.AddAsync(group);
@@ -129,14 +121,10 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var user = new UserBuilder().WithSub(userSub).Build();
             var admin = new UserBuilder().WithSub(adminSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = admin,
-                Name = "A group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
-            var userToGroup = new UserToGroup { Group = group, User = user };
-            var adminToGroup = new UserToGroup { Group = group, User = admin };
+            var userToGroup = new UserToGroup {Group = group, User = user};
+            var adminToGroup = new UserToGroup {Group = group, User = admin};
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Groups.AddAsync(group);

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/LeaveGroupValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/LeaveGroupValidatorShould.cs
@@ -65,11 +65,7 @@ namespace DeUrgenta.Group.Api.Tests.Validators
 
             var user = new UserBuilder().WithSub(userSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = user,
-                Name = "my group"
-            };
+            var group = new GroupBuilder().WithAdmin(user).Build();
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Groups.AddAsync(group);
@@ -93,13 +89,9 @@ namespace DeUrgenta.Group.Api.Tests.Validators
 
             var user = new UserBuilder().WithSub(userSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = user,
-                Name = "my group"
-            };
+            var group = new GroupBuilder().WithAdmin(user).Build();
 
-            var userToGroups = new UserToGroup { Group = group, User = user };
+            var userToGroups = new UserToGroup {Group = group, User = user};
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Groups.AddAsync(group);
@@ -124,13 +116,9 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var user = new UserBuilder().WithSub(userSub).Build();
             var admin = new UserBuilder().WithSub(adminSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = admin,
-                Name = "my group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
-            var userToGroups = new UserToGroup { Group = group, User = user };
+            var userToGroups = new UserToGroup {Group = group, User = user};
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Groups.AddAsync(group);

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/RemoveFromGroupValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/RemoveFromGroupValidatorShould.cs
@@ -47,15 +47,11 @@ namespace DeUrgenta.Group.Api.Tests.Validators
 
             var admin = new UserBuilder().WithSub(userSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = admin,
-                Name = "my group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
             await _dbContext.Users.AddAsync(admin);
             await _dbContext.Groups.AddAsync(group);
-            await _dbContext.UsersToGroups.AddAsync(new UserToGroup { Group = group, User = admin });
+            await _dbContext.UsersToGroups.AddAsync(new UserToGroup {Group = group, User = admin});
 
             await _dbContext.SaveChangesAsync();
 
@@ -64,7 +60,6 @@ namespace DeUrgenta.Group.Api.Tests.Validators
 
             // Assert
             isValid.Should().BeFalse();
-
         }
 
         [Fact]
@@ -77,15 +72,11 @@ namespace DeUrgenta.Group.Api.Tests.Validators
 
             var admin = new UserBuilder().WithSub(userSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = admin,
-                Name = "my group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
             await _dbContext.Users.AddAsync(admin);
             await _dbContext.Groups.AddAsync(group);
-            await _dbContext.UsersToGroups.AddAsync(new UserToGroup { Group = group, User = admin });
+            await _dbContext.UsersToGroups.AddAsync(new UserToGroup {Group = group, User = admin});
 
             await _dbContext.SaveChangesAsync();
 
@@ -132,18 +123,14 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var admin = new UserBuilder().WithSub(userSub).Build();
             var groupUser = new UserBuilder().WithSub(groupUserSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = admin,
-                Name = "my group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
             await _dbContext.Users.AddAsync(admin);
             await _dbContext.Users.AddAsync(groupUser);
 
             await _dbContext.Groups.AddAsync(group);
-            await _dbContext.UsersToGroups.AddAsync(new UserToGroup { Group = group, User = admin });
-            await _dbContext.UsersToGroups.AddAsync(new UserToGroup { Group = group, User = groupUser });
+            await _dbContext.UsersToGroups.AddAsync(new UserToGroup {Group = group, User = admin});
+            await _dbContext.UsersToGroups.AddAsync(new UserToGroup {Group = group, User = groupUser});
 
             await _dbContext.SaveChangesAsync();
 
@@ -166,17 +153,13 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var admin = new UserBuilder().WithSub(userSub).Build();
             var groupUser = new UserBuilder().WithSub(groupUserSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = admin,
-                Name = "my group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
             await _dbContext.Users.AddAsync(admin);
             await _dbContext.Users.AddAsync(groupUser);
             await _dbContext.Groups.AddAsync(group);
-            await _dbContext.UsersToGroups.AddAsync(new UserToGroup { Group = group, User = admin });
-            await _dbContext.UsersToGroups.AddAsync(new UserToGroup { Group = group, User = groupUser });
+            await _dbContext.UsersToGroups.AddAsync(new UserToGroup {Group = group, User = admin});
+            await _dbContext.UsersToGroups.AddAsync(new UserToGroup {Group = group, User = groupUser});
 
             await _dbContext.SaveChangesAsync();
 

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/UpdateGroupValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/UpdateGroupValidatorShould.cs
@@ -69,18 +69,14 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var admin = new UserBuilder().WithSub(userSub).Build();
             var groupUser = new UserBuilder().WithSub(groupUserSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = admin,
-                Name = "my group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
             await _dbContext.Users.AddAsync(admin);
             await _dbContext.Users.AddAsync(groupUser);
 
             await _dbContext.Groups.AddAsync(group);
-            await _dbContext.UsersToGroups.AddAsync(new UserToGroup { Group = group, User = admin });
-            await _dbContext.UsersToGroups.AddAsync(new UserToGroup { Group = group, User = groupUser });
+            await _dbContext.UsersToGroups.AddAsync(new UserToGroup {Group = group, User = admin});
+            await _dbContext.UsersToGroups.AddAsync(new UserToGroup {Group = group, User = groupUser});
 
             await _dbContext.SaveChangesAsync();
 
@@ -101,15 +97,11 @@ namespace DeUrgenta.Group.Api.Tests.Validators
 
             var admin = new UserBuilder().WithSub(userSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = admin,
-                Name = "my group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
             await _dbContext.Users.AddAsync(admin);
             await _dbContext.Groups.AddAsync(group);
-            await _dbContext.UsersToGroups.AddAsync(new UserToGroup { Group = group, User = admin });
+            await _dbContext.UsersToGroups.AddAsync(new UserToGroup {Group = group, User = admin});
 
             await _dbContext.SaveChangesAsync();
 

--- a/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/UpdateSafeLocationValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.Group.Api.Tests/Validators/UpdateSafeLocationValidatorShould.cs
@@ -32,7 +32,8 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var sut = new UpdateSafeLocationValidator(_dbContext);
 
             // Act
-            var isValid = await sut.IsValidAsync(new UpdateSafeLocation(sub, Guid.NewGuid(), new SafeLocationRequest()));
+            var isValid =
+                await sut.IsValidAsync(new UpdateSafeLocation(sub, Guid.NewGuid(), new SafeLocationRequest()));
 
             // Assert
             isValid.Should().BeFalse();
@@ -50,7 +51,8 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var sut = new UpdateSafeLocationValidator(_dbContext);
 
             // Act
-            var isValid = await sut.IsValidAsync(new UpdateSafeLocation(userSub, Guid.NewGuid(), new SafeLocationRequest()));
+            var isValid =
+                await sut.IsValidAsync(new UpdateSafeLocation(userSub, Guid.NewGuid(), new SafeLocationRequest()));
 
             // Assert
             isValid.Should().BeFalse();
@@ -66,17 +68,9 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var user = new UserBuilder().WithSub(userSub).Build();
             var adminUser = new UserBuilder().WithSub(adminSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = adminUser,
-                Name = "a group"
-            };
+            var group = new GroupBuilder().WithAdmin(adminUser).Build();
 
-            var groupSafeLocation = new GroupSafeLocation
-            {
-                Group = group,
-                Name = "A safe location"
-            };
+            var groupSafeLocation = new GroupSafeLocation {Group = group, Name = "A safe location"};
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Users.AddAsync(adminUser);
@@ -87,7 +81,9 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var sut = new UpdateSafeLocationValidator(_dbContext);
 
             // Act
-            var isValid = await sut.IsValidAsync(new UpdateSafeLocation(userSub, groupSafeLocation.Id, new SafeLocationRequest()));
+            var isValid =
+                await sut.IsValidAsync(new UpdateSafeLocation(userSub, groupSafeLocation.Id,
+                    new SafeLocationRequest()));
 
             // Assert
             isValid.Should().BeFalse();
@@ -102,17 +98,9 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             var userSub = Guid.NewGuid().ToString();
             var user = new UserBuilder().WithSub(userSub).Build();
 
-            var group = new Domain.Entities.Group
-            {
-                Admin = user,
-                Name = "my group"
-            };
+            var group = new GroupBuilder().WithAdmin(user).Build();
 
-            var groupSafeLocation = new GroupSafeLocation
-            {
-                Group = group,
-                Name = "A safe location"
-            };
+            var groupSafeLocation = new GroupSafeLocation {Group = group, Name = "A safe location"};
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Groups.AddAsync(group);
@@ -120,7 +108,9 @@ namespace DeUrgenta.Group.Api.Tests.Validators
             await _dbContext.SaveChangesAsync();
 
             // Act
-            var isValid = await sut.IsValidAsync(new UpdateSafeLocation(userSub, groupSafeLocation.Id, new SafeLocationRequest()));
+            var isValid =
+                await sut.IsValidAsync(new UpdateSafeLocation(userSub, groupSafeLocation.Id,
+                    new SafeLocationRequest()));
 
             // Assert
             isValid.Should().BeTrue();

--- a/Src/Tests/DeUrgenta.Tests.Helpers/Builders/GroupBuilder.cs
+++ b/Src/Tests/DeUrgenta.Tests.Helpers/Builders/GroupBuilder.cs
@@ -1,0 +1,17 @@
+using DeUrgenta.Domain.Entities;
+
+namespace DeUrgenta.Tests.Helpers.Builders
+{
+    public class GroupBuilder
+    {
+        private User _admin = new User();
+
+        public Group Build() => new Group {Admin = _admin, Name = TestDataProviders.RandomString()};
+
+        public GroupBuilder WithAdmin(User admin)
+        {
+            _admin = admin;
+            return this;
+        }
+    }
+}

--- a/Src/Tests/DeUrgenta.User.Api.Tests/Validators/AcceptGroupInviteValidator.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/Validators/AcceptGroupInviteValidator.cs
@@ -19,10 +19,11 @@ namespace DeUrgenta.User.Api.Tests.Validators
     {
         private readonly DeUrgentaContext _dbContext;
         private readonly IOptions<GroupsConfig> _defaultOptions = Substitute.For<IOptions<GroupsConfig>>();
+
         public AcceptGroupInviteValidatorShould(DatabaseFixture fixture)
         {
             _dbContext = fixture.Context;
-            _defaultOptions.Value.Returns(new GroupsConfig { UsersLimit = 30 });
+            _defaultOptions.Value.Returns(new GroupsConfig {UsersLimit = 30});
         }
 
         [Theory]
@@ -60,20 +61,11 @@ namespace DeUrgenta.User.Api.Tests.Validators
             await _dbContext.Users.AddAsync(admin);
             await _dbContext.Users.AddAsync(otherUser);
 
-            var group = new Group
-            {
-                Admin = admin,
-                Name = "group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
             await _dbContext.Groups.AddAsync(group);
 
-            var groupInvite = new GroupInvite
-            {
-                InvitationReceiver = user,
-                InvitationSender = admin,
-                Group = group
-            };
+            var groupInvite = new GroupInvite {InvitationReceiver = user, InvitationSender = admin, Group = group};
 
             await _dbContext.GroupInvites.AddAsync(groupInvite);
             await _dbContext.SaveChangesAsync();
@@ -100,11 +92,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Users.AddAsync(admin);
 
-            var group = new Group
-            {
-                Admin = admin,
-                Name = "group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
             await _dbContext.Groups.AddAsync(group);
 
@@ -121,36 +109,30 @@ namespace DeUrgenta.User.Api.Tests.Validators
         public async Task Invalidate_when_exceeds_group_users_limit()
         {
             var options = Substitute.For<IOptions<GroupsConfig>>();
-            options.Value.Returns(new GroupsConfig { UsersLimit = 2 });
+            options.Value.Returns(new GroupsConfig {UsersLimit = 2});
             var sut = new AcceptGroupInviteValidator(_dbContext, options);
 
             // Arrange
             var userSub = Guid.NewGuid().ToString();
             var user = new UserBuilder().WithSub(userSub).Build();
-            
+
             var secondUserSub = Guid.NewGuid().ToString();
             var secondUser = new UserBuilder().WithSub(secondUserSub).Build();
-            
+
             var adminSub = Guid.NewGuid().ToString();
             var admin = new UserBuilder().WithSub(adminSub).Build();
 
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Users.AddAsync(admin);
 
-            var group = new Group
-            {
-                Admin = admin,
-                Name = "group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
-            await _dbContext.UsersToGroups.AddAsync(new UserToGroup { Group = group, User = admin });
-            await _dbContext.UsersToGroups.AddAsync(new UserToGroup { Group = group, User = user });
-            
+            await _dbContext.UsersToGroups.AddAsync(new UserToGroup {Group = group, User = admin});
+            await _dbContext.UsersToGroups.AddAsync(new UserToGroup {Group = group, User = user});
+
             var groupInvite = new GroupInvite
             {
-                InvitationReceiver = secondUser,
-                InvitationSender = admin,
-                Group = group
+                InvitationReceiver = secondUser, InvitationSender = admin, Group = group
             };
             await _dbContext.GroupInvites.AddAsync(groupInvite);
             await _dbContext.Groups.AddAsync(group);
@@ -163,7 +145,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             // Assert
             isValid.Should().BeFalse();
         }
-        
+
         [Fact]
         public async Task Validate_when_an_invite_exists()
         {
@@ -179,18 +161,9 @@ namespace DeUrgenta.User.Api.Tests.Validators
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Users.AddAsync(admin);
 
-            var group = new Group
-            {
-                Admin = admin,
-                Name = "group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
-            var groupInvite = new GroupInvite
-            {
-                InvitationReceiver = user,
-                InvitationSender = admin,
-                Group = group
-            };
+            var groupInvite = new GroupInvite {InvitationReceiver = user, InvitationSender = admin, Group = group};
             await _dbContext.GroupInvites.AddAsync(groupInvite);
             await _dbContext.Groups.AddAsync(group);
 

--- a/Src/Tests/DeUrgenta.User.Api.Tests/Validators/RejectGroupInviteValidatorShould.cs
+++ b/Src/Tests/DeUrgenta.User.Api.Tests/Validators/RejectGroupInviteValidatorShould.cs
@@ -56,20 +56,11 @@ namespace DeUrgenta.User.Api.Tests.Validators
             await _dbContext.Users.AddAsync(admin);
             await _dbContext.Users.AddAsync(otherUser);
 
-            var group = new Group
-            {
-                Admin = admin,
-                Name = "group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
             await _dbContext.Groups.AddAsync(group);
 
-            var groupInvite = new GroupInvite
-            {
-                InvitationReceiver = user,
-                InvitationSender = admin,
-                Group = group
-            };
+            var groupInvite = new GroupInvite {InvitationReceiver = user, InvitationSender = admin, Group = group};
 
             await _dbContext.GroupInvites.AddAsync(groupInvite);
             await _dbContext.SaveChangesAsync();
@@ -96,11 +87,7 @@ namespace DeUrgenta.User.Api.Tests.Validators
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Users.AddAsync(admin);
 
-            var group = new Group
-            {
-                Admin = admin,
-                Name = "group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
             await _dbContext.Groups.AddAsync(group);
 
@@ -128,18 +115,9 @@ namespace DeUrgenta.User.Api.Tests.Validators
             await _dbContext.Users.AddAsync(user);
             await _dbContext.Users.AddAsync(admin);
 
-            var group = new Group
-            {
-                Admin = admin,
-                Name = "group"
-            };
+            var group = new GroupBuilder().WithAdmin(admin).Build();
 
-            var groupInvite = new GroupInvite
-            {
-                InvitationReceiver = user,
-                InvitationSender = admin,
-                Group = group
-            };
+            var groupInvite = new GroupInvite {InvitationReceiver = user, InvitationSender = admin, Group = group};
             await _dbContext.GroupInvites.AddAsync(groupInvite);
             await _dbContext.Groups.AddAsync(group);
 


### PR DESCRIPTION
### What does it fix?

Closes #68 

Added MaxNumberOfMembers to GroupModel, which means that create and update group endpoints return the max number of members, but also for get-administrated-groups and get-my-groups.

Also wrote a GroupBuilder and moved all tests to using that :)

### How has it been tested?

Wrote tests for all cases