### PR TITLE
Added a concurrency token to backpack items

### DIFF
--- a/Src/DeUrgenta.Backpack.Api/CommandHandlers/AddBackpackItemHandler.cs
+++ b/Src/DeUrgenta.Backpack.Api/CommandHandlers/AddBackpackItemHandler.cs
@@ -50,7 +50,8 @@ namespace DeUrgenta.Backpack.Api.CommandHandlers
                 Amount = backpackItem.Amount,
                 CategoryType = backpackItem.BackpackCategory,
                 ExpirationDate = backpackItem.ExpirationDate,
-                BackpackId = request.BackpackId
+                BackpackId = request.BackpackId,
+                Version = 0
             };
         }
     }

--- a/Src/DeUrgenta.Backpack.Api/CommandHandlers/UpdateBackpackItemHandler.cs
+++ b/Src/DeUrgenta.Backpack.Api/CommandHandlers/UpdateBackpackItemHandler.cs
@@ -33,15 +33,18 @@ namespace DeUrgenta.Backpack.Api.CommandHandlers
             backpackItem.BackpackCategory = request.BackpackItem.CategoryType;
             backpackItem.Amount = request.BackpackItem.Amount;
             backpackItem.ExpirationDate = request.BackpackItem.ExpirationDate;
+            backpackItem.Version += 1;
 
             await _context.SaveChangesAsync(cancellationToken);
 
             return new BackpackItemModel
             {
                 Id = backpackItem.Id,
+                Name = backpackItem.Name,
                 Amount = backpackItem.Amount,
                 CategoryType = backpackItem.BackpackCategory,
-                ExpirationDate = backpackItem.ExpirationDate
+                ExpirationDate = backpackItem.ExpirationDate,
+                Version = backpackItem.Version
             };
         }
     }

--- a/Src/DeUrgenta.Backpack.Api/Controllers/BackpackItemController.cs
+++ b/Src/DeUrgenta.Backpack.Api/Controllers/BackpackItemController.cs
@@ -80,7 +80,7 @@ namespace DeUrgenta.Backpack.Api.Controllers
         [SwaggerResponse(StatusCodes.Status400BadRequest, "A business rule was violated", typeof(ProblemDetails))]
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Something bad happened", typeof(ProblemDetails))]
 
-        [SwaggerRequestExample(typeof(BackpackItemRequest), typeof(AddOrUpdateBackpackItemRequestExample))]
+        [SwaggerRequestExample(typeof(BackpackItemRequest), typeof(AddBackpackItemRequestExample))]
         [SwaggerResponseExample(StatusCodes.Status200OK, typeof(AddBackpackItemResponseExample))]
         [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(BusinessRuleViolationResponseExample))]
         [SwaggerResponseExample(StatusCodes.Status500InternalServerError, typeof(ApplicationErrorResponseExample))]
@@ -104,8 +104,8 @@ namespace DeUrgenta.Backpack.Api.Controllers
         [SwaggerResponse(StatusCodes.Status400BadRequest, "A business rule was violated", typeof(ProblemDetails))]
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Something bad happened", typeof(ProblemDetails))]
 
-        [SwaggerRequestExample(typeof(BackpackItemRequest), typeof(AddOrUpdateBackpackItemRequestExample))]
-        [SwaggerResponseExample(StatusCodes.Status200OK, typeof(AddBackpackItemResponseExample))]
+        [SwaggerRequestExample(typeof(BackpackItemRequest), typeof(UpdateBackpackItemRequestExample))]
+        [SwaggerResponseExample(StatusCodes.Status200OK, typeof(UpdateBackpackItemResponseExample))]
         [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(BusinessRuleViolationResponseExample))]
         [SwaggerResponseExample(StatusCodes.Status500InternalServerError, typeof(ApplicationErrorResponseExample))]
         public async Task<ActionResult<BackpackItemModel>> UpdateBackpackItemAsync([FromRoute] Guid itemId, [FromBody] BackpackItemRequest backpackItem)

--- a/Src/DeUrgenta.Backpack.Api/Models/BackpackItemModel.cs
+++ b/Src/DeUrgenta.Backpack.Api/Models/BackpackItemModel.cs
@@ -11,5 +11,6 @@ namespace DeUrgenta.Backpack.Api.Models
         public uint Amount { get; init; }
         public DateTime? ExpirationDate { get; init; }
         public BackpackCategoryType CategoryType { get; set; }
+        public ulong Version { get; set; }
     }
 }

--- a/Src/DeUrgenta.Backpack.Api/Models/BackpackItemRequest.cs
+++ b/Src/DeUrgenta.Backpack.Api/Models/BackpackItemRequest.cs
@@ -12,5 +12,7 @@ namespace DeUrgenta.Backpack.Api.Models
         public DateTime? ExpirationDate { get; init; }
 
         public BackpackCategoryType CategoryType { get; init; }
+        
+        public ulong Version { get; init; }
     }
 }

--- a/Src/DeUrgenta.Backpack.Api/QueryHandlers/GetBackpackItemsHandler.cs
+++ b/Src/DeUrgenta.Backpack.Api/QueryHandlers/GetBackpackItemsHandler.cs
@@ -39,7 +39,8 @@ namespace DeUrgenta.Backpack.Api.QueryHandlers
                     Amount = item.Amount,
                     Name = item.Name,
                     CategoryType = item.BackpackCategory,
-                    ExpirationDate = item.ExpirationDate
+                    ExpirationDate = item.ExpirationDate,
+                    Version = item.Version
                 })
                 .ToListAsync(cancellationToken);
 

--- a/Src/DeUrgenta.Backpack.Api/Swagger/BackpackItem/AddBackpackItemRequestExample.cs
+++ b/Src/DeUrgenta.Backpack.Api/Swagger/BackpackItem/AddBackpackItemRequestExample.cs
@@ -1,19 +1,21 @@
 ﻿using System;
 using DeUrgenta.Backpack.Api.Models;
+using DeUrgenta.Domain.Api.Entities;
 using Swashbuckle.AspNetCore.Filters;
 
 namespace DeUrgenta.Backpack.Api.Swagger.BackpackItem
 {
-    public class AddBackpackItemResponseExample : IExamplesProvider<BackpackItemRequest>
+    public class AddBackpackItemRequestExample : IExamplesProvider<BackpackItemModel>
     {
-        public BackpackItemRequest GetExamples()
+        public BackpackItemModel GetExamples()
         {
             return new()
             {
+                Id = Guid.NewGuid(),
                 Name = "Hering conserva",
                 Amount = 5,
                 ExpirationDate = DateTime.Today.AddDays(720),
-                Version = 3
+                CategoryType = BackpackCategoryType.WaterAndFood
             };
         }
     }

--- a/Src/DeUrgenta.Backpack.Api/Swagger/BackpackItem/UpdateBackpackItemRequestExample.cs
+++ b/Src/DeUrgenta.Backpack.Api/Swagger/BackpackItem/UpdateBackpackItemRequestExample.cs
@@ -1,18 +1,21 @@
 ﻿using System;
 using DeUrgenta.Backpack.Api.Models;
+using DeUrgenta.Domain.Api.Entities;
 using Swashbuckle.AspNetCore.Filters;
 
 namespace DeUrgenta.Backpack.Api.Swagger.BackpackItem
 {
-    public class AddBackpackItemResponseExample : IExamplesProvider<BackpackItemRequest>
+    public class UpdateBackpackItemRequestExample : IExamplesProvider<BackpackItemModel>
     {
-        public BackpackItemRequest GetExamples()
+        public BackpackItemModel GetExamples()
         {
             return new()
             {
+                Id = Guid.NewGuid(),
                 Name = "Hering conserva",
                 Amount = 5,
                 ExpirationDate = DateTime.Today.AddDays(720),
+                CategoryType = BackpackCategoryType.WaterAndFood,
                 Version = 3
             };
         }

--- a/Src/DeUrgenta.Backpack.Api/Swagger/BackpackItem/UpdateBackpackItemResponseExample.cs
+++ b/Src/DeUrgenta.Backpack.Api/Swagger/BackpackItem/UpdateBackpackItemResponseExample.cs
@@ -1,21 +1,19 @@
 ﻿using System;
 using DeUrgenta.Backpack.Api.Models;
-using DeUrgenta.Domain.Api.Entities;
 using Swashbuckle.AspNetCore.Filters;
 
 namespace DeUrgenta.Backpack.Api.Swagger.BackpackItem
 {
-    public class AddOrUpdateBackpackItemRequestExample : IExamplesProvider<BackpackItemModel>
+    public class UpdateBackpackItemResponseExample : IExamplesProvider<BackpackItemRequest>
     {
-        public BackpackItemModel GetExamples()
+        public BackpackItemRequest GetExamples()
         {
             return new()
             {
-                Id = Guid.NewGuid(),
                 Name = "Hering conserva",
                 Amount = 5,
                 ExpirationDate = DateTime.Today.AddDays(720),
-                CategoryType = BackpackCategoryType.WaterAndFood
+                Version = 3
             };
         }
     }

--- a/Src/DeUrgenta.Backpack.Api/Validators/UpdateBackpackItemValidator.cs
+++ b/Src/DeUrgenta.Backpack.Api/Validators/UpdateBackpackItemValidator.cs
@@ -35,6 +35,11 @@ namespace DeUrgenta.Backpack.Api.Validators
                 return ValidationResult.GenericValidationError;
             }
 
+            if (!request.BackpackItem.Version.Equals(backpackItem.Version))
+            {
+                return ValidationResult.GenericValidationError;
+            }
+            
             return ValidationResult.Ok;
         }
     }

--- a/Src/DeUrgenta.Domain.Api/Configurations/BackpackItemEntityConfiguration.cs
+++ b/Src/DeUrgenta.Domain.Api/Configurations/BackpackItemEntityConfiguration.cs
@@ -37,6 +37,11 @@ namespace DeUrgenta.Domain.Api.Configurations
                 .WithMany(x => x.BackpackItems)
                 .HasForeignKey(x => x.BackpackId)
                 .HasConstraintName("FK_BackpackItem_Backpack");
+
+            builder
+                .Property(e => e.Version)
+                .IsRequired()
+                .HasDefaultValue(0);
         }
     }
 }

--- a/Src/DeUrgenta.Domain.Api/Entities/BackpackItem.cs
+++ b/Src/DeUrgenta.Domain.Api/Entities/BackpackItem.cs
@@ -11,8 +11,8 @@ namespace DeUrgenta.Domain.Api.Entities
         public uint Amount { get; set; }
         public DateTime? ExpirationDate { get; set; }
         public BackpackCategoryType BackpackCategory { get; set; }
-
         public virtual Backpack Backpack { get; set; }
         public virtual Guid BackpackId { get; set; }
+        public ulong Version { get; set; }
     }
 }

--- a/Src/DeUrgenta.Domain.Api/Migrations/20211015114916_AddBackpackItemConcurrencyToken.Designer.cs
+++ b/Src/DeUrgenta.Domain.Api/Migrations/20211015114916_AddBackpackItemConcurrencyToken.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using DeUrgenta.Domain.Api;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace DeUrgenta.Domain.Migrations
 {
     [DbContext(typeof(DeUrgentaContext))]
-    partial class DeUrgentaContextModelSnapshot : ModelSnapshot
+    [Migration("20211015114916_AddBackpackItemConcurrencyToken")]
+    partial class AddBackpackItemConcurrencyToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Src/DeUrgenta.Domain.Api/Migrations/20211015114916_AddBackpackItemConcurrencyToken.cs
+++ b/Src/DeUrgenta.Domain.Api/Migrations/20211015114916_AddBackpackItemConcurrencyToken.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace DeUrgenta.Domain.Migrations
+{
+    public partial class AddBackpackItemConcurrencyToken : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "Version",
+                table: "BackpackItems",
+                type: "numeric(20,0)",
+                nullable: false,
+                defaultValue: 0m);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Version",
+                table: "BackpackItems");
+        }
+    }
+}

--- a/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/UpdateBackpackItemHandlerShould.cs
+++ b/Src/Tests/DeUrgenta.Backpack.Api.Tests/CommandHandlers/UpdateBackpackItemHandlerShould.cs
@@ -1,13 +1,19 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DeUrgenta.Backpack.Api.Commands;
 using DeUrgenta.Backpack.Api.CommandHandlers;
+using DeUrgenta.Backpack.Api.Models;
+using DeUrgenta.Backpack.Api.Validators;
 using DeUrgenta.Common.Validation;
 using DeUrgenta.Domain.Api;
+using DeUrgenta.Domain.Api.Entities;
 using DeUrgenta.Tests.Helpers;
+using DeUrgenta.Tests.Helpers.Builders;
 using NSubstitute;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
@@ -23,6 +29,70 @@ namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
         }
 
         [Fact]
+        public async Task Successfully_update_backpack_item()
+        {
+            // Arrange
+            var validator = new UpdateBackpackItemValidator(_dbContext);
+            var sut = new UpdateBackpackItemHandler(validator, _dbContext);
+
+            var user = new UserBuilder().Build();
+            var backpack = new BackpackBuilder().Build();
+            var backpackToUser = new BackpackToUser {Backpack = backpack, User = user};
+            var backpackItem = new BackpackItemBuilder().WithBackpack(backpack).Build();
+            backpack.BackpackItems.Add(backpackItem);
+            await _dbContext.BackpacksToUsers.AddAsync(backpackToUser);
+            await _dbContext.SaveChangesAsync();
+
+            // First assertion
+            _dbContext.BackpackItems.Where(i => i.Id.Equals(backpackItem.Id)).First().Version.Should().Be(0);
+            
+            // Act
+            var result = await sut.Handle(
+                new UpdateBackpackItem(
+                    user.Sub,
+                    backpackItem.Id,
+                    new BackpackItemRequest() {Name = "test", Version = 0}
+                ),
+                CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Name.Should().Be("test");
+            result.Value.Version.Should().Be(1);
+        }
+        
+        [Fact]
+        public async Task Fail_to_update_using_outdated_model()
+        {
+            // Arrange
+            var validator = new UpdateBackpackItemValidator(_dbContext);
+            var sut = new UpdateBackpackItemHandler(validator, _dbContext);
+
+            var user = new UserBuilder().Build();
+            var backpack = new BackpackBuilder().Build();
+            var backpackToUser = new BackpackToUser {Backpack = backpack, User = user};
+            var backpackItem = new BackpackItemBuilder().WithBackpack(backpack).Build();
+            backpack.BackpackItems.Add(backpackItem);
+            await _dbContext.BackpacksToUsers.AddAsync(backpackToUser);
+            await _dbContext.SaveChangesAsync();
+
+            // First assertion
+            _dbContext.BackpackItems.Where(i => i.Id.Equals(backpackItem.Id)).First().Version.Should().Be(0);
+            
+            // Act
+            var result = await sut.Handle(
+                new UpdateBackpackItem(
+                    user.Sub,
+                    backpackItem.Id,
+                    new BackpackItemRequest() {Name = "test", Version = 4}
+                ),
+                CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeFalse();
+        }
+
+        [Fact]
         public async Task Return_failed_result_when_validation_fails()
         {
             // Arrange
@@ -34,7 +104,9 @@ namespace DeUrgenta.Backpack.Api.Tests.CommandHandlers
             var sut = new UpdateBackpackItemHandler(validator, _dbContext);
 
             // Act
-            var result = await sut.Handle(new UpdateBackpackItem("a-sub", Guid.NewGuid(), new Models.BackpackItemRequest()), CancellationToken.None);
+            var result =
+                await sut.Handle(new UpdateBackpackItem("a-sub", Guid.NewGuid(), new Models.BackpackItemRequest()),
+                    CancellationToken.None);
 
             // Assert
             result.IsFailure.Should().BeTrue();

--- a/Src/Tests/DeUrgenta.Tests.Helpers/Builders/BackpackBuilder.cs
+++ b/Src/Tests/DeUrgenta.Tests.Helpers/Builders/BackpackBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using DeUrgenta.Domain.Api.Entities;
 
 namespace DeUrgenta.Tests.Helpers.Builders
@@ -6,16 +6,16 @@ namespace DeUrgenta.Tests.Helpers.Builders
     public class BackpackBuilder
     {
         private Guid _id = Guid.NewGuid();
-
+        
         public Backpack Build() => new()
         {
-            Name = TestDataProviders.RandomString(),
-            Id = _id
+            Id = _id,
+            Name = TestDataProviders.RandomString()
         };
 
-        public BackpackBuilder WithId(Guid backpackId)
+        public BackpackBuilder WithId(Guid id)
         {
-            _id = backpackId;
+            _id = id;
             return this;
         }
     }

--- a/Src/Tests/DeUrgenta.Tests.Helpers/Builders/BackpackItemBuilder.cs
+++ b/Src/Tests/DeUrgenta.Tests.Helpers/Builders/BackpackItemBuilder.cs
@@ -1,23 +1,26 @@
-﻿using System;
+using System;
 using DeUrgenta.Domain.Api.Entities;
 
 namespace DeUrgenta.Tests.Helpers.Builders
 {
     public class BackpackItemBuilder
     {
+        private Guid _id = Guid.NewGuid();
         private DateTime? _expirationDate = null;
-        private readonly Backpack _backpack = new BackpackBuilder().Build();
+        private Backpack _backpack = new BackpackBuilder().Build();
         private BackpackCategoryType _category = BackpackCategoryType.FirstAid;
-
+        private ulong _version;
+        
         public BackpackItem Build() => new()
         {
-            Id = Guid.NewGuid(),
+            Id = _id,
             Amount = 2,
             ExpirationDate = _expirationDate,
             Name = TestDataProviders.RandomString(),
             BackpackCategory = _category,
             BackpackId = Guid.NewGuid(),
-            Backpack = _backpack
+            Backpack = _backpack,
+            Version = _version
         };
 
         public BackpackItemBuilder WithExpirationDate(DateTime? expirationDate)
@@ -29,6 +32,24 @@ namespace DeUrgenta.Tests.Helpers.Builders
         public BackpackItemBuilder WithCategory(BackpackCategoryType backpackCategoryType)
         {
             _category = backpackCategoryType;
+            return this;
+        }
+        
+        public BackpackItemBuilder WithId(Guid id)
+        {
+            _id = id;
+            return this;
+        }
+        
+        public BackpackItemBuilder WithBackpack(Backpack backpack)
+        {
+            _backpack = backpack;
+            return this;
+        }
+
+        public BackpackItemBuilder WithVersion(ulong version)
+        {
+            _version = version;
             return this;
         }
     }

--- a/Src/Tests/DeUrgenta.Tests.Helpers/Builders/UserBuilder.cs
+++ b/Src/Tests/DeUrgenta.Tests.Helpers/Builders/UserBuilder.cs
@@ -5,21 +5,21 @@ namespace DeUrgenta.Tests.Helpers.Builders
 {
     public class UserBuilder
     {
-        private Guid _userId = Guid.NewGuid();
+        private Guid _id = Guid.NewGuid();
         private string _sub = Guid.NewGuid().ToString();
 
         public User Build() => new()
         {
-            Id = _userId,
+            Id = _id,
             FirstName = TestDataProviders.RandomString(),
             LastName = TestDataProviders.RandomString(),
             Sub = _sub,
-            Email = $"{_userId}@example.com"
+            Email = $"{_id}@example.com"
         };
 
-        public UserBuilder WithId(Guid userId)
+        public UserBuilder WithId(Guid id)
         {
-            _userId = userId;
+            _id = id;
             return this;
         }
 


### PR DESCRIPTION
### What does it fix?

Closes #125 

This adds a 'version' field in the backpack item models which is used to determine if the model we based our changes on is the latest version in order to prevent concurrency problems.

### How has it been tested?

Wrote two tests, one for each case.