### PR TITLE
Create endpoint to refresh a user's JWT token

### DIFF
--- a/Src/DeUrgenta.User.Api/Controller/AuthController.cs
+++ b/Src/DeUrgenta.User.Api/Controller/AuthController.cs
@@ -14,6 +14,7 @@ using DeUrgenta.User.Api.Queries;
 using DeUrgenta.User.Api.Services;
 using DeUrgenta.User.Api.Swagger.Auth;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -259,6 +260,24 @@ namespace DeUrgenta.User.Api.Controller
 
             return Ok();
 
+        }
+
+        [HttpGet]
+        [Authorize]
+        [Route("refresh-token")]
+        public async Task<IActionResult> RequestRefreshJwtToken() {
+
+            var userEmail = User.Claims.FirstOrDefault(c => c.Type == "email")?.Value;
+            var user = await _userManager.FindByEmailAsync(userEmail);
+
+            var userRoles = await _userManager.GetRolesAsync(user);
+            var newJwtToken = _jwtService.GenerateJwtToken(user, userRoles);
+
+            return Ok(new {
+                Email = userEmail,
+                Token = newJwtToken,
+                Success = true
+            });
         }
     }
 }


### PR DESCRIPTION
I assumed a user would need to already be logged in for this to make sense, hence the Authorize attribute. I'm not sure this is the right way to do it as the old token is still valid.

I also assumed the endpoint probably shouldn't ask for the login information as this would be no different from the login endpoint.

Closes #162 